### PR TITLE
Fix duplicate recipes created for legacy sensor-less records

### DIFF
--- a/src/domain/recipes/operations.py
+++ b/src/domain/recipes/operations.py
@@ -243,25 +243,79 @@ def get_or_create_recipe_from_data(
     data = recipe_normalization.normalize_recipe_data(data)
     recipe_validation.validate_recipe_data(data)
     signature = recipe_sensors.compute_sensor_signature(data.sensors)
+    film_simulation = data.film_simulation
+    dynamic_range = data.dynamic_range or ""
+    d_range_priority = data.d_range_priority
+    grain_roughness = data.grain_roughness
+    grain_size = data.grain_size if data.grain_size is not None else "Off"
+    color_chrome_effect = data.color_chrome_effect
+    color_chrome_fx_blue = data.color_chrome_fx_blue
+    white_balance = data.white_balance
+    white_balance_red = data.white_balance_red
+    white_balance_blue = data.white_balance_blue
+    highlight = _parse_numeric(s=data.highlight)
+    shadow = _parse_numeric(s=data.shadow)
+    color = _parse_numeric(s=data.color)
+    sharpness = _parse_numeric(s=data.sharpness)
+    high_iso_nr = _parse_numeric(s=data.high_iso_nr)
+    clarity = _parse_numeric(s=data.clarity)
+    monochromatic_color_warm_cool = _parse_numeric(s=data.monochromatic_color_warm_cool)
+    monochromatic_color_magenta_green = _parse_numeric(s=data.monochromatic_color_magenta_green)
+    if signature:
+        # If a recipe with the same settings exists but was created before sensor
+        # tracking was introduced (sensor_signature=''), upgrade it in place rather
+        # than creating a duplicate. Recipes with two distinct non-empty signatures
+        # (e.g. 'x-trans iv' vs 'x-trans v') remain intentionally separate.
+        try:
+            recipe = models.FujifilmRecipe.objects.get(
+                film_simulation=film_simulation,
+                dynamic_range=dynamic_range,
+                d_range_priority=d_range_priority,
+                grain_roughness=grain_roughness,
+                grain_size=grain_size,
+                color_chrome_effect=color_chrome_effect,
+                color_chrome_fx_blue=color_chrome_fx_blue,
+                white_balance=white_balance,
+                white_balance_red=white_balance_red,
+                white_balance_blue=white_balance_blue,
+                highlight=highlight,
+                shadow=shadow,
+                color=color,
+                sharpness=sharpness,
+                high_iso_nr=high_iso_nr,
+                clarity=clarity,
+                monochromatic_color_warm_cool=monochromatic_color_warm_cool,
+                monochromatic_color_magenta_green=monochromatic_color_magenta_green,
+                sensor_signature="",
+            )
+            set_recipe_sensors(recipe=recipe, sensor_names=data.sensors)
+            events.publish_event(
+                event_type=events.RECIPE_DEDUPLICATED,
+                recipe_id=recipe.pk,
+                film_simulation=recipe.film_simulation,
+            )
+            return recipe, False
+        except models.FujifilmRecipe.DoesNotExist:
+            pass
     recipe, created = models.FujifilmRecipe.get_or_create(
-        film_simulation=data.film_simulation,
-        dynamic_range=data.dynamic_range or "",
-        d_range_priority=data.d_range_priority,
-        grain_roughness=data.grain_roughness,
-        grain_size=data.grain_size if data.grain_size is not None else "Off",
-        color_chrome_effect=data.color_chrome_effect,
-        color_chrome_fx_blue=data.color_chrome_fx_blue,
-        white_balance=data.white_balance,
-        white_balance_red=data.white_balance_red,
-        white_balance_blue=data.white_balance_blue,
-        highlight=_parse_numeric(s=data.highlight),
-        shadow=_parse_numeric(s=data.shadow),
-        color=_parse_numeric(s=data.color),
-        sharpness=_parse_numeric(s=data.sharpness),
-        high_iso_nr=_parse_numeric(s=data.high_iso_nr),
-        clarity=_parse_numeric(s=data.clarity),
-        monochromatic_color_warm_cool=_parse_numeric(s=data.monochromatic_color_warm_cool),
-        monochromatic_color_magenta_green=_parse_numeric(s=data.monochromatic_color_magenta_green),
+        film_simulation=film_simulation,
+        dynamic_range=dynamic_range,
+        d_range_priority=d_range_priority,
+        grain_roughness=grain_roughness,
+        grain_size=grain_size,
+        color_chrome_effect=color_chrome_effect,
+        color_chrome_fx_blue=color_chrome_fx_blue,
+        white_balance=white_balance,
+        white_balance_red=white_balance_red,
+        white_balance_blue=white_balance_blue,
+        highlight=highlight,
+        shadow=shadow,
+        color=color,
+        sharpness=sharpness,
+        high_iso_nr=high_iso_nr,
+        clarity=clarity,
+        monochromatic_color_warm_cool=monochromatic_color_warm_cool,
+        monochromatic_color_magenta_green=monochromatic_color_magenta_green,
         sensor_signature=signature,
         name=data.name,
         description=data.description,

--- a/tests/integration/domain/recipes/test_get_or_create_recipe_from_data.py
+++ b/tests/integration/domain/recipes/test_get_or_create_recipe_from_data.py
@@ -26,7 +26,7 @@ def _make_data(**overrides: object) -> image_dataclasses.FujifilmRecipeData:
         color="0",
     )
     base.update(overrides)
-    return image_dataclasses.FujifilmRecipeData(**base)
+    return image_dataclasses.FujifilmRecipeData(**base)  # type: ignore[arg-type]  # test helper merges typed defaults with arbitrary overrides via dict
 
 
 @pytest.mark.django_db
@@ -45,14 +45,14 @@ class TestGetOrCreateRecipeFromData:
         assert created is False
         assert models.FujifilmRecipe.objects.count() == 1
 
-    def test_publishes_created_event_on_first_call(self, captured_logs) -> None:
+    def test_publishes_created_event_on_first_call(self, captured_logs: list[dict[str, object]]) -> None:
         recipe, _ = get_or_create_recipe_from_data(data=_make_data())
 
         created_events = [e for e in captured_logs if e.get("event_type") == events.RECIPE_CREATED]
         assert len(created_events) == 1
         assert created_events[0]["recipe_id"] == recipe.pk
 
-    def test_publishes_deduplicated_event_on_subsequent_call(self, captured_logs) -> None:
+    def test_publishes_deduplicated_event_on_subsequent_call(self, captured_logs: list[dict[str, object]]) -> None:
         recipe, _ = get_or_create_recipe_from_data(data=_make_data())
         captured_logs.clear()
         get_or_create_recipe_from_data(data=_make_data())
@@ -175,7 +175,7 @@ class TestGetOrCreateRecipeFromDataVersionLine:
 
 @pytest.mark.django_db
 class TestGetOrCreateRecipeFromDataWithSensors:
-    def test_attaches_sensors_to_new_recipe(self):
+    def test_attaches_sensors_to_new_recipe(self) -> None:
         recipe, _ = get_or_create_recipe_from_data(
             data=_make_data(sensors=("X-Trans IV", "GFX"), white_balance_red=8001)
         )
@@ -183,7 +183,7 @@ class TestGetOrCreateRecipeFromDataWithSensors:
         assert sorted(s.name for s in recipe.sensors.all()) == ["GFX", "X-Trans IV"]
         assert recipe.sensor_signature == "gfx,x-trans iv"
 
-    def test_same_settings_different_sensors_yield_distinct_recipes(self):
+    def test_same_settings_different_sensors_yield_distinct_recipes(self) -> None:
         first, created_first = get_or_create_recipe_from_data(
             data=_make_data(sensors=("X-Trans IV",), white_balance_red=8002)
         )
@@ -194,7 +194,7 @@ class TestGetOrCreateRecipeFromDataWithSensors:
         assert created_first and created_second
         assert first.pk != second.pk
 
-    def test_same_settings_same_sensors_dedup(self):
+    def test_same_settings_same_sensors_dedup(self) -> None:
         first, _ = get_or_create_recipe_from_data(
             data=_make_data(sensors=("X-Trans IV", "GFX"), white_balance_red=8003)
         )
@@ -208,7 +208,7 @@ class TestGetOrCreateRecipeFromDataWithSensors:
         # The M2M was attached only once -- two sensors, not four.
         assert first.sensors.count() == 2
 
-    def test_empty_sensors_leaves_recipe_without_m2m_and_with_blank_signature(self):
+    def test_empty_sensors_leaves_recipe_without_m2m_and_with_blank_signature(self) -> None:
         recipe, _ = get_or_create_recipe_from_data(
             data=_make_data(white_balance_red=8004)
         )
@@ -216,10 +216,56 @@ class TestGetOrCreateRecipeFromDataWithSensors:
         assert list(recipe.sensors.all()) == []
         assert recipe.sensor_signature == ""
 
+    def test_finds_legacy_recipe_with_empty_signature_when_sensor_provided(self) -> None:
+        legacy, _ = get_or_create_recipe_from_data(data=_make_data(white_balance_red=8010))
+        legacy.set_sensor_signature(sensor_signature="")
+
+        recipe, created = get_or_create_recipe_from_data(
+            data=_make_data(sensors=("X-Trans IV",), white_balance_red=8010)
+        )
+
+        assert created is False
+        assert recipe.pk == legacy.pk
+        recipe.refresh_from_db()
+        assert recipe.sensor_signature == "x-trans iv"
+
+    def test_legacy_recipe_gets_m2m_sensors_set(self) -> None:
+        legacy, _ = get_or_create_recipe_from_data(data=_make_data(white_balance_red=8011))
+        legacy.set_sensor_signature(sensor_signature="")
+
+        recipe, _ = get_or_create_recipe_from_data(
+            data=_make_data(sensors=("X-Trans IV",), white_balance_red=8011)
+        )
+
+        assert recipe.sensors.filter(name="X-Trans IV").exists()
+
+    def test_non_empty_to_non_empty_different_signatures_still_create_distinct_recipes(self) -> None:
+        get_or_create_recipe_from_data(
+            data=_make_data(sensors=("X-Trans IV",), white_balance_red=8012)
+        )
+        _, created = get_or_create_recipe_from_data(
+            data=_make_data(sensors=("X-Trans V",), white_balance_red=8012)
+        )
+
+        assert created is True
+        assert models.FujifilmRecipe.objects.filter(white_balance_red=8012).count() == 2
+
+    def test_legacy_path_publishes_deduplicated_not_created_event(self, captured_logs: list[dict[str, object]]) -> None:
+        legacy, _ = get_or_create_recipe_from_data(data=_make_data(white_balance_red=8013))
+        legacy.set_sensor_signature(sensor_signature="")
+        captured_logs.clear()
+
+        get_or_create_recipe_from_data(
+            data=_make_data(sensors=("X-Trans IV",), white_balance_red=8013)
+        )
+
+        assert not [e for e in captured_logs if e.get("event_type") == events.RECIPE_CREATED]
+        assert [e for e in captured_logs if e.get("event_type") == events.RECIPE_DEDUPLICATED]
+
 
 @pytest.mark.django_db
 class TestGetOrCreateRecipeFromDataWithDescription:
-    def test_description_written_on_create(self):
+    def test_description_written_on_create(self) -> None:
         recipe, _ = get_or_create_recipe_from_data(
             data=_make_data(description="Recipe notes here.", white_balance_red=8005)
         )
@@ -227,7 +273,7 @@ class TestGetOrCreateRecipeFromDataWithDescription:
         recipe.refresh_from_db()
         assert recipe.description == "Recipe notes here."
 
-    def test_description_not_overwritten_on_dedup_path(self):
+    def test_description_not_overwritten_on_dedup_path(self) -> None:
         original, _ = get_or_create_recipe_from_data(
             data=_make_data(description="Original notes", white_balance_red=8006)
         )
@@ -239,7 +285,7 @@ class TestGetOrCreateRecipeFromDataWithDescription:
         original.refresh_from_db()
         assert original.description == "Original notes"
 
-    def test_description_defaults_to_empty_string(self):
+    def test_description_defaults_to_empty_string(self) -> None:
         recipe, _ = get_or_create_recipe_from_data(
             data=_make_data(white_balance_red=8007)
         )


### PR DESCRIPTION
## Summary

- Importing images from a camera could silently create duplicate recipes
  in the library when the same recipe settings already existed under a
  different sensor association. The import operation treated sensor
  information as part of the recipe's identity for lookup purposes, so
  any mismatch — including recipes that predated sensor tracking and had
  none recorded — caused a new recipe record to be created instead of
  finding the existing one.
- Fix: when importing an image, if the recipe settings match an existing
  sensor-less record, that record is upgraded in place with the sensor
  information from the image rather than producing a duplicate. Recipes
  with genuinely different sensor associations (e.g. two different camera
  generations) remain distinct, as intended.
