### PR TITLE
Fix sync progress label to count skipped and errors

### DIFF
--- a/src/application/usecases/library/dataclasses.py
+++ b/src/application/usecases/library/dataclasses.py
@@ -19,6 +19,7 @@ class SyncRunData:
     processed: int
     skipped: int
     errors: int
+    handled: int
     percent: int
     is_active: bool
     is_scanning: bool

--- a/src/interfaces/library/views.py
+++ b/src/interfaces/library/views.py
@@ -35,6 +35,7 @@ def _sync_status(run: models.SyncRun) -> library_dataclasses.SyncRunData:
         processed=run.processed,
         skipped=run.skipped,
         errors=run.errors,
+        handled=handled,
         percent=percent,
         is_active=run.state in models.SyncRun.ACTIVE_STATES,
         is_scanning=run.state == models.SyncRun.STATE_SCANNING,

--- a/src/interfaces/templates/library/partials/sync_status.html
+++ b/src/interfaces/templates/library/partials/sync_status.html
@@ -10,7 +10,7 @@
     {% if status.is_scanning %}
       <span class="sync-status__label">Scanning…</span>
     {% elif status.is_processing %}
-      <span class="sync-status__label">Processing {{ status.processed }}/{{ status.total }}</span>
+      <span class="sync-status__label">Processing {{ status.handled }}/{{ status.total }}</span>
       <progress class="sync-status__bar" value="{{ status.percent }}" max="100"></progress>
     {% elif status.is_completed %}
       <span class="sync-status__label sync-status__label--done">Imported {{ status.processed }}{% if status.skipped %}, skipped {{ status.skipped }}{% endif %}{% if status.errors %}, {{ status.errors }} error{{ status.errors|pluralize }}{% endif %}</span>

--- a/tests/functional/test_library_sync_status_view.py
+++ b/tests/functional/test_library_sync_status_view.py
@@ -39,6 +39,22 @@ class TestLibraryFolderSyncStatus:
         assert 'hx-trigger="every 2s"' in content
         assert "<progress" in content
 
+    def test_processing_label_counts_skipped_and_errors(self, client):
+        # Regression: the label must show total handled (processed+skipped+errors),
+        # not just processed — otherwise non-Fujifilm folders show "0/N" forever
+        # while the progress bar advances.
+        folder = LibraryFolderFactory()
+        run = SyncRunFactory(folder=folder, state=models.SyncRun.STATE_PROCESSING, total=10)
+        run.processed = 0
+        run.skipped = 3
+        run.errors = 1
+        run.save(update_fields=["processed", "skipped", "errors"])
+
+        response = client.get(f"/library/{folder.pk}/sync-status/")
+
+        content = response.content.decode()
+        assert "Processing 4/10" in content
+
     def test_shows_summary_and_stops_polling_when_completed(self, client):
         folder = LibraryFolderFactory()
         run = SyncRunFactory(folder=folder, state=models.SyncRun.STATE_COMPLETED, total=3)


### PR DESCRIPTION
## Summary

The "Processing X/N" label during library sync was only counting successfully
imported images (`processed`), while the progress bar was driven by all handled
images (`processed + skipped + errors`). For folders containing mostly
duplicates files the bar would advance while the counter stayed at 0/N throughout the sync.

**Fix:** adds a `handled` field to `SyncRunData` (already computed in the view
as `processed + skipped + errors`) and uses it in the `sync_status.html`
template label, making the counter consistent with the bar.