### PR TITLE
Minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-make<img src="src/interfaces/static/images/filmcase_primary_aligned_readme.png" alt="Filmcase" width="400">
+<img src="src/interfaces/static/images/filmcase_primary_aligned_readme.png" alt="Filmcase" width="400">
 
 Filmcase is a Django application for managing Fujifilm camera recipes and browsing your image catalog. It reads EXIF data from your JPEG files, matches images to the Fujifilm recipe they were shot with, and lets you filter and group your catalog by recipe. You can push recipes directly to your camera over USB and explore relationships between recipes through an interactive graph.
 

--- a/src/domain/images/queries.py
+++ b/src/domain/images/queries.py
@@ -485,6 +485,7 @@ class ImageDetailContext:
     image: models.Image
     prev_id: int | None
     next_id: int | None
+    is_monochromatic: bool
 
 
 def get_image_detail(
@@ -520,10 +521,16 @@ def get_image_detail(
     except ValueError:
         idx = -1
 
+    recipe = image.fujifilm_recipe
+
     return ImageDetailContext(
         image=image,
         prev_id=ids[idx - 1] if idx > 0 else None,
         next_id=ids[idx + 1] if idx < len(ids) - 1 else None,
+        is_monochromatic=(
+            recipe is not None
+            and recipe.film_simulation in recipe_constants.MONOCHROMATIC_FILM_SIMULATIONS
+        ),
     )
 
 

--- a/src/interfaces/images/views.py
+++ b/src/interfaces/images/views.py
@@ -86,6 +86,7 @@ class ImageDetail(generic.View):
                 "image": detail.image,
                 "prev_id": detail.prev_id,
                 "next_id": detail.next_id,
+                "is_monochromatic": detail.is_monochromatic,
                 "max_rating": max_rating,
                 "rating_range": rating_range,
             })
@@ -103,6 +104,7 @@ class ImageDetail(generic.View):
             "image": detail.image,
             "prev_id": detail.prev_id,
             "next_id": detail.next_id,
+            "is_monochromatic": detail.is_monochromatic,
             "max_rating": max_rating,
             "rating_range": rating_range,
         })

--- a/src/interfaces/templates/images/_image_detail_partial.html
+++ b/src/interfaces/templates/images/_image_detail_partial.html
@@ -261,6 +261,32 @@
     opacity: 0.7;
   }
 
+  .detail-recipe-actions {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  .view-recipe-btn {
+    flex-shrink: 0;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--color-accent);
+    background: transparent;
+    border: 1px solid var(--color-accent);
+    border-radius: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+    text-decoration: none;
+    transition: background 0.15s, color 0.15s;
+  }
+
+  .view-recipe-btn:hover {
+    background: var(--color-accent);
+    color: #fff;
+  }
+
   .recipe-name-input-row {
     display: flex;
     align-items: center;
@@ -555,7 +581,8 @@
             </div>
           {% endif %}
 
-          <div class="detail-row">
+          <div class="detail-row detail-recipe-actions">
+            <a class="view-recipe-btn" href="{% url 'recipe-detail' recipe_id=image.fujifilm_recipe_id %}">View recipe</a>
             {% include "images/_set_cover_image_btn.html" with recipe_id=image.fujifilm_recipe_id image_id=image.id %}
           </div>
         </section>

--- a/src/interfaces/templates/images/_image_detail_partial.html
+++ b/src/interfaces/templates/images/_image_detail_partial.html
@@ -268,6 +268,7 @@
   .settings-section--white-balance { grid-column: 1; grid-row: 3; }
   .settings-section--dynamic-range { grid-column: 2; grid-row: 1; }
   .settings-section--color-chrome  { grid-column: 2; grid-row: 2; }
+  .settings-section--bw-tone       { grid-column: 2; grid-row: 3; }
 
   .settings-section-header {
     font-size: 0.7rem;
@@ -582,6 +583,34 @@
                   <span class="settings-row-value">{{ image.fujifilm_recipe.color_chrome_fx_blue }}</span>
                 </div>
               </div>
+
+              {% if is_monochromatic %}
+                <div class="settings-section settings-section--bw-tone">
+                  <div class="settings-section-header">BW Tone</div>
+                  <div class="settings-row">
+                    <span class="settings-row-label">
+                      <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
+                        <line x1="1" y1="7" x2="13" y2="7"/>
+                        <polyline points="4,4.5 1,7 4,9.5"/>
+                        <polyline points="10,4.5 13,7 10,9.5"/>
+                      </svg>
+                      BW Warm / Cool
+                    </span>
+                    <span class="settings-row-value">{{ image.fujifilm_recipe.monochromatic_color_warm_cool|signed }}</span>
+                  </div>
+                  <div class="settings-row">
+                    <span class="settings-row-label">
+                      <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
+                        <line x1="7" y1="1" x2="7" y2="13"/>
+                        <polyline points="4.5,4 7,1 9.5,4"/>
+                        <polyline points="4.5,10 7,13 9.5,10"/>
+                      </svg>
+                      BW Magenta / Green
+                    </span>
+                    <span class="settings-row-value">{{ image.fujifilm_recipe.monochromatic_color_magenta_green|signed }}</span>
+                  </div>
+                </div>
+              {% endif %}
 
             </div>{# /right column #}
 

--- a/src/interfaces/templates/images/_image_detail_partial.html
+++ b/src/interfaces/templates/images/_image_detail_partial.html
@@ -187,50 +187,6 @@
     word-break: break-word;
   }
 
-  .detail-name-row {
-    display: flex;
-    align-items: center;
-    gap: 0.6rem;
-  }
-
-  .send-to-camera-btn {
-    flex-shrink: 0;
-    padding: 0.2rem 0.55rem;
-    font-size: 0.7rem;
-    font-weight: 600;
-    color: var(--color-accent);
-    background: transparent;
-    border: 1px solid var(--color-accent);
-    border-radius: 4px;
-    cursor: pointer;
-    white-space: nowrap;
-    transition: background 0.15s, color 0.15s;
-  }
-
-  .send-to-camera-btn:hover {
-    background: var(--color-accent);
-    color: #fff;
-  }
-
-  .name-recipe-btn {
-    flex-shrink: 0;
-    padding: 0.2rem 0.55rem;
-    font-size: 0.7rem;
-    font-weight: 600;
-    color: #888;
-    background: transparent;
-    border: 1px solid #555;
-    border-radius: 4px;
-    cursor: pointer;
-    white-space: nowrap;
-    transition: border-color 0.15s, color 0.15s;
-  }
-
-  .name-recipe-btn:hover {
-    border-color: #aaa;
-    color: #ddd;
-  }
-
   .set-cover-btn {
     flex-shrink: 0;
     padding: 0.2rem 0.55rem;
@@ -287,58 +243,6 @@
     color: #fff;
   }
 
-  .recipe-name-input-row {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-  }
-
-  .recipe-name-input {
-    flex: 1;
-    padding: 0.2rem 0.4rem;
-    font-size: 0.85rem;
-    background: #2a2a2a;
-    border: 1px solid #555;
-    border-radius: 4px;
-    color: #ddd;
-    min-width: 0;
-  }
-
-  .recipe-name-input:focus {
-    outline: none;
-    border-color: var(--color-accent);
-  }
-
-  .recipe-name-ok-btn {
-    padding: 0.2rem 0.55rem;
-    font-size: 0.7rem;
-    font-weight: 600;
-    color: #fff;
-    background: var(--color-accent);
-    border: 1px solid var(--color-accent);
-    border-radius: 4px;
-    cursor: pointer;
-    white-space: nowrap;
-  }
-
-  .recipe-name-cancel-btn {
-    padding: 0.2rem 0.55rem;
-    font-size: 0.7rem;
-    font-weight: 600;
-    color: #888;
-    background: transparent;
-    border: 1px solid #555;
-    border-radius: 4px;
-    cursor: pointer;
-    white-space: nowrap;
-  }
-
-  .recipe-name-error {
-    display: block;
-    font-size: 0.75rem;
-    color: #e05c5c;
-    margin-bottom: 0.3rem;
-  }
 </style>
 
 <div class="detail-overlay">
@@ -442,20 +346,10 @@
         <section class="detail-recipe">
           <h2 class="detail-section-title">Fujifilm Recipe</h2>
 
-          {% if image.fujifilm_recipe.name %}
-            <div class="detail-row">
-              <span class="detail-label">Name</span>
-              <div class="detail-name-row">
-                <span class="detail-value">{{ image.fujifilm_recipe.name }}</span>
-                <button class="send-to-camera-btn"
-                        hx-get="{% url 'select-push-slot' recipe_id=image.fujifilm_recipe.id %}"
-                        hx-target="#slot-overlay"
-                        hx-swap="innerHTML">Send to camera</button>
-              </div>
-            </div>
-          {% else %}
-            {% include "recipes/_recipe_name_prompt.html" with recipe=image.fujifilm_recipe %}
-          {% endif %}
+          <div class="detail-row">
+            <span class="detail-label">Name</span>
+            <span class="detail-value">{{ image.fujifilm_recipe.name|default:"—" }}</span>
+          </div>
 
           {% if image.fujifilm_recipe.film_simulation %}
             <div class="detail-row">

--- a/src/interfaces/templates/images/_image_detail_partial.html
+++ b/src/interfaces/templates/images/_image_detail_partial.html
@@ -187,17 +187,52 @@
     word-break: break-word;
   }
 
-  .set-cover-btn {
-    flex-shrink: 0;
-    padding: 0.2rem 0.55rem;
-    font-size: 0.7rem;
+  /* Recipe actions sit on one line directly under the section title, over the
+     same two columns the settings below use. Each button is centred in its
+     column; the shared min-width keeps them equal regardless of label length.
+     (The cover control ships wrapped in its own div for HTMX swaps, which
+     justify-items centres just like the link.) */
+  .detail-recipe-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    justify-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .view-recipe-btn,
+  .set-cover-btn,
+  .cover-image-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    /* Shared width keeps both buttons equal; capped at the column width so a
+       narrow panel makes them fill it rather than overflow. */
+    min-width: min(12.5rem, 100%);
+    padding: 0.4rem 0.7rem;
+    font-size: 0.75rem;
     font-weight: 600;
-    color: var(--color-accent);
-    background: transparent;
     border: 1px solid var(--color-accent);
-    border-radius: 4px;
-    cursor: pointer;
+    border-radius: 6px;
     white-space: nowrap;
+    text-align: center;
+    text-decoration: none;
+  }
+
+  .view-recipe-btn {
+    background: var(--color-accent);
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .view-recipe-btn:hover { background: var(--color-accent-dark); }
+
+  .set-cover-btn {
+    background: transparent;
+    color: var(--color-accent);
+    cursor: pointer;
     transition: background 0.15s, color 0.15s;
   }
 
@@ -207,40 +242,9 @@
   }
 
   .cover-image-badge {
-    display: inline-block;
-    padding: 0.2rem 0.55rem;
-    font-size: 0.7rem;
-    font-weight: 600;
-    color: var(--color-accent);
-    border: 1px solid var(--color-accent);
-    border-radius: 4px;
-    opacity: 0.7;
-  }
-
-  .detail-recipe-actions {
-    flex-direction: row;
-    align-items: center;
-    gap: 0.6rem;
-  }
-
-  .view-recipe-btn {
-    flex-shrink: 0;
-    padding: 0.2rem 0.55rem;
-    font-size: 0.7rem;
-    font-weight: 600;
-    color: var(--color-accent);
     background: transparent;
-    border: 1px solid var(--color-accent);
-    border-radius: 4px;
-    cursor: pointer;
-    white-space: nowrap;
-    text-decoration: none;
-    transition: background 0.15s, color 0.15s;
-  }
-
-  .view-recipe-btn:hover {
-    background: var(--color-accent);
-    color: #fff;
+    color: var(--color-accent);
+    opacity: 0.7;
   }
 
 </style>
@@ -345,6 +349,11 @@
       {% if image.fujifilm_recipe %}
         <section class="detail-recipe">
           <h2 class="detail-section-title">Fujifilm Recipe</h2>
+
+          <div class="detail-recipe-actions">
+            <a class="view-recipe-btn" href="{% url 'recipe-detail' recipe_id=image.fujifilm_recipe_id %}">View recipe</a>
+            {% include "images/_set_cover_image_btn.html" with recipe_id=image.fujifilm_recipe_id image_id=image.id %}
+          </div>
 
           <div class="detail-row">
             <span class="detail-label">Name</span>
@@ -474,11 +483,6 @@
               {% endif %}
             </div>
           {% endif %}
-
-          <div class="detail-row detail-recipe-actions">
-            <a class="view-recipe-btn" href="{% url 'recipe-detail' recipe_id=image.fujifilm_recipe_id %}">View recipe</a>
-            {% include "images/_set_cover_image_btn.html" with recipe_id=image.fujifilm_recipe_id image_id=image.id %}
-          </div>
         </section>
       {% endif %}
 

--- a/src/interfaces/templates/images/_image_detail_partial.html
+++ b/src/interfaces/templates/images/_image_detail_partial.html
@@ -247,6 +247,76 @@
     opacity: 0.7;
   }
 
+  /* Recipe settings, grouped into sections across two columns in the same
+     order as the recipe detail view. */
+  .settings-grid,
+  .settings-bottom {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.25rem 1.5rem;
+  }
+
+  .settings-grid { margin-bottom: 1.25rem; }
+
+  /* The column wrappers collapse so the sections become grid items directly.
+     Pairing them onto explicit rows keeps each pair's tops aligned (Grain
+     with Color Chrome) even when a value wraps onto a second line. */
+  .settings-grid > div { display: contents; }
+
+  .settings-section--basic         { grid-column: 1; grid-row: 1; }
+  .settings-section--grain         { grid-column: 1; grid-row: 2; }
+  .settings-section--white-balance { grid-column: 1; grid-row: 3; }
+  .settings-section--dynamic-range { grid-column: 2; grid-row: 1; }
+  .settings-section--color-chrome  { grid-column: 2; grid-row: 2; }
+
+  .settings-section-header {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #9a9a9a;
+    margin-bottom: 0.4rem;
+  }
+
+  .settings-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.3rem 0 0.3rem 0.5rem;
+  }
+
+  .settings-row-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #666;
+  }
+
+  .settings-row-value {
+    min-width: 0;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: #ddd;
+    text-align: right;
+    word-break: break-word;
+  }
+
+  .settings-row-value--red  { color: var(--color-accent); }
+  .settings-row-value--blue { color: #60a5fa; }
+
+  .field-icon {
+    width: 13px;
+    height: 13px;
+    flex-shrink: 0;
+    opacity: 0.8;
+  }
+
 </style>
 
 <div class="detail-overlay">
@@ -355,134 +425,251 @@
             {% include "images/_set_cover_image_btn.html" with recipe_id=image.fujifilm_recipe_id image_id=image.id %}
           </div>
 
-          <div class="detail-row">
-            <span class="detail-label">Name</span>
-            <span class="detail-value">{{ image.fujifilm_recipe.name|default:"—" }}</span>
-          </div>
+          <div class="settings-grid">
 
-          {% if image.fujifilm_recipe.film_simulation %}
-            <div class="detail-row">
-              <span class="detail-label">Film Simulation</span>
-              <span class="detail-value">{{ image.fujifilm_recipe.film_simulation }}</span>
-            </div>
-          {% endif %}
+            {# LEFT COLUMN: BASIC · GRAIN · WHITE BALANCE #}
+            <div>
 
-          {% if image.fujifilm_recipe.dynamic_range or image.fujifilm_recipe.d_range_priority %}
-            <div class="detail-row-group">
-              {% if image.fujifilm_recipe.dynamic_range %}
-                <div class="detail-cell">
-                  <span class="detail-label">Dynamic Range</span>
-                  <span class="detail-value">{{ image.fujifilm_recipe.dynamic_range }}</span>
+              <div class="settings-section settings-section--basic">
+                <div class="settings-section-header">Basic</div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M1.5 2.5 L8 2.5 L12.5 7 L8 11.5 L1.5 11.5 Z"/>
+                      <circle cx="4.5" cy="7" r="1" fill="currentColor" stroke="none"/>
+                    </svg>
+                    Name
+                  </span>
+                  <span class="settings-row-value">{{ image.fujifilm_recipe.name|default:"—" }}</span>
                 </div>
-              {% endif %}
-              {% if image.fujifilm_recipe.d_range_priority %}
-                <div class="detail-cell">
-                  <span class="detail-label">D-Range Priority</span>
-                  <span class="detail-value">{{ image.fujifilm_recipe.d_range_priority }}</span>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+                      <rect x="1" y="2.5" width="12" height="9" rx="0.8"/>
+                      <rect x="1.2" y="4" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
+                      <rect x="1.2" y="8.2" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
+                      <rect x="10.6" y="4" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
+                      <rect x="10.6" y="8.2" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
+                      <line x1="4.8" y1="2.5" x2="4.8" y2="11.5" stroke-width="0.7" opacity="0.45"/>
+                      <line x1="9.2" y1="2.5" x2="9.2" y2="11.5" stroke-width="0.7" opacity="0.45"/>
+                    </svg>
+                    Film Sim
+                  </span>
+                  <span class="settings-row-value">{{ image.fujifilm_recipe.film_simulation }}</span>
                 </div>
-              {% endif %}
-            </div>
-          {% endif %}
-
-          {% if image.fujifilm_recipe.grain_roughness or image.fujifilm_recipe.grain_size %}
-            <div class="detail-row-group">
-              {% if image.fujifilm_recipe.grain_roughness %}
-                <div class="detail-cell">
-                  <span class="detail-label">Grain Roughness</span>
-                  <span class="detail-value">{{ image.fujifilm_recipe.grain_roughness }}</span>
-                </div>
-              {% endif %}
-              {% if image.fujifilm_recipe.grain_size %}
-                <div class="detail-cell">
-                  <span class="detail-label">Grain Size</span>
-                  <span class="detail-value">{{ image.fujifilm_recipe.grain_size }}</span>
-                </div>
-              {% endif %}
-            </div>
-          {% endif %}
-
-          {% if image.fujifilm_recipe.color_chrome_effect or image.fujifilm_recipe.color_chrome_fx_blue %}
-            <div class="detail-row-group">
-              {% if image.fujifilm_recipe.color_chrome_effect %}
-                <div class="detail-cell">
-                  <span class="detail-label">Color Chrome Effect</span>
-                  <span class="detail-value">{{ image.fujifilm_recipe.color_chrome_effect }}</span>
-                </div>
-              {% endif %}
-              {% if image.fujifilm_recipe.color_chrome_fx_blue %}
-                <div class="detail-cell">
-                  <span class="detail-label">Color Chrome FX Blue</span>
-                  <span class="detail-value">{{ image.fujifilm_recipe.color_chrome_fx_blue }}</span>
-                </div>
-              {% endif %}
-            </div>
-          {% endif %}
-
-          {% if image.fujifilm_recipe.white_balance %}
-            <div class="detail-row-group">
-              <div class="detail-cell">
-                <span class="detail-label">White Balance</span>
-                <span class="detail-value">{{ image.fujifilm_recipe.white_balance }}</span>
               </div>
-              <div class="detail-cell">
-                <span class="detail-label">Red</span>
-                <span class="detail-value">{{ image.fujifilm_recipe.white_balance_red|signed }}</span>
-              </div>
-              <div class="detail-cell">
-                <span class="detail-label">Blue</span>
-                <span class="detail-value">{{ image.fujifilm_recipe.white_balance_blue|signed }}</span>
-              </div>
-            </div>
-          {% endif %}
 
-          {% if image.fujifilm_recipe.highlight is not None or image.fujifilm_recipe.shadow is not None %}
-            <div class="detail-row-group">
-              {% if image.fujifilm_recipe.highlight is not None %}
-                <div class="detail-cell">
-                  <span class="detail-label">Highlight</span>
-                  <span class="detail-value">{{ image.fujifilm_recipe.highlight|signed }}</span>
+              <div class="settings-section settings-section--grain">
+                <div class="settings-section-header">Grain</div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="currentColor">
+                      <circle cx="3" cy="3.5" r="1.1"/>
+                      <circle cx="8.5" cy="2.5" r="1.1"/>
+                      <circle cx="12" cy="5.5" r="1.1"/>
+                      <circle cx="5.5" cy="7.5" r="1.1"/>
+                      <circle cx="11" cy="9.5" r="1.1"/>
+                      <circle cx="2.5" cy="11" r="1.1"/>
+                      <circle cx="7.5" cy="11.5" r="1.1"/>
+                    </svg>
+                    Grain Roughness
+                  </span>
+                  <span class="settings-row-value">{{ image.fujifilm_recipe.grain_roughness }}</span>
                 </div>
-              {% endif %}
-              {% if image.fujifilm_recipe.shadow is not None %}
-                <div class="detail-cell">
-                  <span class="detail-label">Shadow</span>
-                  <span class="detail-value">{{ image.fujifilm_recipe.shadow|signed }}</span>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="currentColor">
+                      <circle cx="4" cy="9" r="3.5"/>
+                      <circle cx="10.5" cy="5" r="1.8"/>
+                    </svg>
+                    Grain Size
+                  </span>
+                  <span class="settings-row-value">{{ image.fujifilm_recipe.grain_size }}</span>
                 </div>
-              {% endif %}
-              <div class="detail-cell">
-                <span class="detail-label">Color</span>
-                <span class="detail-value">{{ image.fujifilm_recipe.color|signed }}</span>
+              </div>
+
+              <div class="settings-section settings-section--white-balance">
+                <div class="settings-section-header">White Balance</div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M5 9.5 C5 9.5 3.2 8.3 3.2 6.2 A3.8 3.8 0 0 1 10.8 6.2 C10.8 8.3 9 9.5 9 9.5 Z"/>
+                      <line x1="5.2" y1="11" x2="8.8" y2="11"/>
+                      <line x1="5.8" y1="12.5" x2="8.2" y2="12.5"/>
+                    </svg>
+                    White Balance
+                  </span>
+                  <span class="settings-row-value">{{ image.fujifilm_recipe.white_balance }}</span>
+                </div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+                      <line x1="2" y1="7" x2="11" y2="7"/>
+                      <polyline points="8.5,4.5 11,7 8.5,9.5"/>
+                      <text x="1" y="12" font-size="5" fill="currentColor" stroke="none" font-weight="700" font-family="sans-serif">R</text>
+                    </svg>
+                    Red
+                  </span>
+                  <span class="settings-row-value settings-row-value--red">{{ image.fujifilm_recipe.white_balance_red|signed }}</span>
+                </div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+                      <line x1="2" y1="7" x2="11" y2="7"/>
+                      <polyline points="8.5,4.5 11,7 8.5,9.5"/>
+                      <text x="1" y="12" font-size="5" fill="currentColor" stroke="none" font-weight="700" font-family="sans-serif">B</text>
+                    </svg>
+                    Blue
+                  </span>
+                  <span class="settings-row-value settings-row-value--blue">{{ image.fujifilm_recipe.white_balance_blue|signed }}</span>
+                </div>
+              </div>
+
+            </div>{# /left column #}
+
+            {# RIGHT COLUMN: DYNAMIC RANGE · COLOR CHROME #}
+            <div>
+
+              <div class="settings-section settings-section--dynamic-range">
+                <div class="settings-section-header">Dynamic Range</div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="currentColor">
+                      <rect x="1" y="9" width="2.5" height="4" rx="0.3"/>
+                      <rect x="4.5" y="6" width="2.5" height="7" rx="0.3"/>
+                      <rect x="8" y="3.5" width="2.5" height="9.5" rx="0.3"/>
+                      <rect x="11.5" y="6.5" width="1.5" height="6.5" rx="0.3"/>
+                    </svg>
+                    Dynamic Range
+                  </span>
+                  <span class="settings-row-value">{{ image.fujifilm_recipe.dynamic_range }}</span>
+                </div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+                      <line x1="1" y1="4" x2="13" y2="4"/>
+                      <line x1="1" y1="7" x2="10" y2="7"/>
+                      <line x1="1" y1="10" x2="7" y2="10"/>
+                    </svg>
+                    D-Range Priority
+                  </span>
+                  <span class="settings-row-value">{{ image.fujifilm_recipe.d_range_priority }}</span>
+                </div>
+              </div>
+
+              <div class="settings-section settings-section--color-chrome">
+                <div class="settings-section-header">Color Chrome</div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
+                      <polygon points="7,1 13,12 1,12"/>
+                      <line x1="7" y1="1" x2="4" y2="7" stroke-width="0.8" opacity="0.5"/>
+                      <line x1="7" y1="1" x2="7.5" y2="5.5" stroke-width="0.8" opacity="0.5"/>
+                      <line x1="7" y1="1" x2="10.5" y2="8" stroke-width="0.8" opacity="0.5"/>
+                    </svg>
+                    Color Chrome Effect
+                  </span>
+                  <span class="settings-row-value">{{ image.fujifilm_recipe.color_chrome_effect }}</span>
+                </div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+                      <circle cx="7" cy="7" r="5.5"/>
+                      <circle cx="7" cy="7" r="2" fill="currentColor" stroke="none" opacity="0.6"/>
+                    </svg>
+                    Color Chrome FX Blue
+                  </span>
+                  <span class="settings-row-value">{{ image.fujifilm_recipe.color_chrome_fx_blue }}</span>
+                </div>
+              </div>
+
+            </div>{# /right column #}
+
+          </div>{# /.settings-grid #}
+
+          {# BOTTOM: TONE & COLOR · DETAIL #}
+          <div class="settings-bottom">
+
+            <div class="settings-section">
+              <div class="settings-section-header">Tone &amp; Color</div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+                    <circle cx="7" cy="7" r="2.2"/>
+                    <line x1="7" y1="1" x2="7" y2="2"/>
+                    <line x1="7" y1="12" x2="7" y2="13"/>
+                    <line x1="1" y1="7" x2="2" y2="7"/>
+                    <line x1="12" y1="7" x2="13" y2="7"/>
+                    <line x1="2.8" y1="2.8" x2="3.5" y2="3.5"/>
+                    <line x1="10.5" y1="10.5" x2="11.2" y2="11.2"/>
+                    <line x1="11.2" y1="2.8" x2="10.5" y2="3.5"/>
+                    <line x1="3.5" y1="10.5" x2="2.8" y2="11.2"/>
+                  </svg>
+                  Highlight
+                </span>
+                <span class="settings-row-value">{{ image.fujifilm_recipe.highlight|signed }}</span>
+              </div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+                    <path d="M9 2.5 A5 5 0 1 0 9 11.5 A4 4 0 1 1 9 2.5 Z" fill="currentColor" opacity="0.55" stroke="none"/>
+                    <path d="M9 2.5 A5 5 0 1 0 9 11.5 A4 4 0 1 1 9 2.5 Z"/>
+                  </svg>
+                  Shadow
+                </span>
+                <span class="settings-row-value">{{ image.fujifilm_recipe.shadow|signed }}</span>
+              </div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+                    <circle cx="7" cy="7" r="5.5"/>
+                    <circle cx="5" cy="5.5" r="1.1" fill="currentColor" stroke="none"/>
+                    <circle cx="9" cy="5" r="1.1" fill="currentColor" stroke="none"/>
+                    <circle cx="10.2" cy="8.5" r="1.1" fill="currentColor" stroke="none"/>
+                    <circle cx="4.2" cy="9.2" r="1.1" fill="currentColor" stroke="none"/>
+                  </svg>
+                  Color
+                </span>
+                <span class="settings-row-value">{{ image.fujifilm_recipe.color|signed }}</span>
               </div>
             </div>
-          {% else %}
-            <div class="detail-row">
-              <span class="detail-label">Color</span>
-              <span class="detail-value">{{ image.fujifilm_recipe.color|signed }}</span>
-            </div>
-          {% endif %}
 
-          {% if image.fujifilm_recipe.sharpness is not None or image.fujifilm_recipe.high_iso_nr is not None or image.fujifilm_recipe.clarity is not None %}
-            <div class="detail-row-group">
-              {% if image.fujifilm_recipe.sharpness is not None %}
-                <div class="detail-cell">
-                  <span class="detail-label">Sharpness</span>
-                  <span class="detail-value">{{ image.fujifilm_recipe.sharpness|signed }}</span>
-                </div>
-              {% endif %}
-              {% if image.fujifilm_recipe.high_iso_nr is not None %}
-                <div class="detail-cell">
-                  <span class="detail-label">ISO NR</span>
-                  <span class="detail-value">{{ image.fujifilm_recipe.high_iso_nr|signed }}</span>
-                </div>
-              {% endif %}
-              {% if image.fujifilm_recipe.clarity is not None %}
-                <div class="detail-cell">
-                  <span class="detail-label">Clarity</span>
-                  <span class="detail-value">{{ image.fujifilm_recipe.clarity|signed }}</span>
-                </div>
-              {% endif %}
+            <div class="settings-section">
+              <div class="settings-section-header">Detail</div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
+                    <polygon points="7,1 13,7 7,13 1,7"/>
+                    <polygon points="7,3.5 10.5,7 7,10.5 3.5,7" fill="currentColor" opacity="0.25" stroke="none"/>
+                  </svg>
+                  Sharpness
+                </span>
+                <span class="settings-row-value">{{ image.fujifilm_recipe.sharpness|signed }}</span>
+              </div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+                    <polygon points="1,2.5 13,2.5 8.5,7.5 8.5,12 5.5,10.5 5.5,7.5" fill="currentColor" opacity="0.2"/>
+                    <polygon points="1,2.5 13,2.5 8.5,7.5 8.5,12 5.5,10.5 5.5,7.5"/>
+                  </svg>
+                  High ISO NR
+                </span>
+                <span class="settings-row-value">{{ image.fujifilm_recipe.high_iso_nr|signed }}</span>
+              </div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+                    <circle cx="7" cy="7" r="5.5"/>
+                    <circle cx="7" cy="7" r="3.2"/>
+                    <circle cx="7" cy="7" r="1" fill="currentColor" stroke="none"/>
+                  </svg>
+                  Clarity
+                </span>
+                <span class="settings-row-value">{{ image.fujifilm_recipe.clarity|signed }}</span>
+              </div>
             </div>
-          {% endif %}
+
+          </div>{# /.settings-bottom #}
         </section>
       {% endif %}
 

--- a/src/interfaces/templates/images/_set_cover_image_btn.html
+++ b/src/interfaces/templates/images/_set_cover_image_btn.html
@@ -1,10 +1,10 @@
 <div id="cover-image-btn-{{ image_id }}">
   {% if is_cover %}
-    <span class="cover-image-badge">Cover image set</span>
+    <span class="cover-image-badge">Current recipe cover</span>
   {% else %}
     <button class="set-cover-btn"
             hx-post="{% url 'set-recipe-cover-image' recipe_id=recipe_id image_id=image_id %}"
             hx-target="#cover-image-btn-{{ image_id }}"
-            hx-swap="outerHTML">Set as cover</button>
+            hx-swap="outerHTML">Set image as recipe cover</button>
   {% endif %}
 </div>

--- a/src/interfaces/templates/images/gallery.html
+++ b/src/interfaces/templates/images/gallery.html
@@ -379,132 +379,6 @@
     #detail-overlay .detail-overlay {
       height: 100%;
     }
-
-    #slot-overlay {
-      position: fixed;
-      inset: 0;
-      z-index: 200;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: rgba(0,0,0,0.6);
-    }
-
-    #slot-overlay[hidden] { display: none; }
-
-    .slot-card {
-      background: #fff;
-      border-radius: 16px;
-      padding: 2rem;
-      width: 580px;
-      box-shadow: 0 4px 24px rgba(0,0,0,0.2);
-      position: relative;
-      font-family: sans-serif;
-      min-height: 120px;
-      overflow: hidden;
-    }
-
-    .slot-card--loading {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .slot-spinner {
-      width: 2rem;
-      height: 2rem;
-      border: 3px solid #e0e0e0;
-      border-top-color: var(--color-accent);
-      border-radius: 50%;
-      animation: slot-spin 0.7s linear infinite;
-    }
-
-    @keyframes slot-spin { to { transform: rotate(360deg); } }
-
-    .slot-push-loading {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      min-height: 220px;
-      padding: 2rem;
-    }
-
-    .slot-spinner-large {
-      width: 80px;
-      height: 80px;
-      border: 6px solid #e0e0e0;
-      border-top-color: var(--color-accent);
-      border-radius: 50%;
-      animation: slot-spin 0.7s linear infinite;
-    }
-
-    .push-result-center {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      min-height: 220px;
-      padding: 2rem;
-      text-align: center;
-    }
-
-    .push-check-svg {
-      width: 80px;
-      height: 80px;
-      margin-bottom: 1.25rem;
-    }
-
-    .push-check-circle {
-      stroke: var(--color-accent);
-      stroke-width: 2;
-      stroke-dasharray: 166;
-      stroke-dashoffset: 166;
-      stroke-miterlimit: 10;
-      animation: push-stroke 0.6s cubic-bezier(0.65, 0, 0.45, 1) forwards;
-    }
-
-    .push-check-mark {
-      stroke: var(--color-accent);
-      stroke-width: 3;
-      stroke-linecap: round;
-      stroke-linejoin: round;
-      stroke-dasharray: 48;
-      stroke-dashoffset: 48;
-      animation: push-stroke 0.3s cubic-bezier(0.65, 0, 0.45, 1) 0.6s forwards;
-    }
-
-    @keyframes push-stroke { 100% { stroke-dashoffset: 0; } }
-
-    .push-result-message {
-      font-size: 1.3rem;
-      font-weight: 700;
-      color: #222;
-    }
-
-    .push-result-err-message {
-      font-size: 1rem;
-      color: #dc2626;
-      margin-bottom: 1.5rem;
-      line-height: 1.5;
-    }
-
-    .push-retry-btn {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0.75rem 1.5rem;
-      border: 1.5px solid var(--color-accent);
-      border-radius: 12px;
-      background: white;
-      color: var(--color-accent);
-      font-size: 0.95rem;
-      font-weight: 600;
-      cursor: pointer;
-      transition: background 0.15s;
-    }
-
-    .push-retry-btn:hover { background: var(--color-accent-light); }
   </style>
 </head>
 <body>
@@ -592,7 +466,6 @@
 </script>
 
 <div id="detail-overlay" hidden></div>
-<div id="slot-overlay" hidden></div>
 
 <script>
   // Multi-select recipe dropdown with search and removable tags.
@@ -671,30 +544,6 @@
     });
   }());
 
-  // Slot overlay logic.
-  var _slotSpinnerHTML = '<div class="slot-card slot-card--loading"><div class="slot-spinner"></div></div>';
-  var _slotPushLoadingHTML = '<div class="slot-push-loading"><div class="slot-spinner-large"></div></div>';
-
-  function closeSlotOverlay() {
-    var overlay = document.getElementById('slot-overlay');
-    overlay.hidden = true;
-  }
-
-  document.body.addEventListener('htmx:beforeRequest', function (e) {
-    if (e.detail.target && e.detail.target.id === 'slot-overlay') {
-      var overlay = e.detail.target;
-      overlay.innerHTML = _slotSpinnerHTML;
-      overlay.hidden = false;
-    }
-    if (e.detail.target && e.detail.target.id === 'slot-card') {
-      e.detail.target.innerHTML = _slotPushLoadingHTML;
-    }
-  });
-
-  document.getElementById('slot-overlay').addEventListener('click', function (e) {
-    if (e.target === this) closeSlotOverlay();
-  });
-
   // Detail overlay logic.
 
   function closeDetail() {
@@ -753,10 +602,6 @@
   });
 
   document.addEventListener('keydown', function (e) {
-    if (e.key === 'Escape') {
-      var slotOverlay = document.getElementById('slot-overlay');
-      if (slotOverlay && !slotOverlay.hidden) { closeSlotOverlay(); return; }
-    }
     var overlay = document.getElementById('detail-overlay');
     if (!overlay || overlay.hidden) return;
     if (e.key === 'Escape') closeDetail();

--- a/src/interfaces/templates/images/image_detail.html
+++ b/src/interfaces/templates/images/image_detail.html
@@ -339,124 +339,6 @@
     }
 
     #detail-overlay .detail-overlay { height: 100%; }
-
-    #slot-overlay {
-      position: fixed;
-      inset: 0;
-      z-index: 200;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: rgba(0,0,0,0.6);
-    }
-
-    #slot-overlay[hidden] { display: none; }
-
-    .slot-card {
-      background: #fff;
-      border-radius: 16px;
-      padding: 2rem;
-      width: 580px;
-      box-shadow: 0 4px 24px rgba(0,0,0,0.2);
-      position: relative;
-      font-family: sans-serif;
-      min-height: 120px;
-      overflow: hidden;
-    }
-
-    .slot-card--loading {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .slot-spinner {
-      width: 2rem;
-      height: 2rem;
-      border: 3px solid #e0e0e0;
-      border-top-color: var(--color-accent);
-      border-radius: 50%;
-      animation: slot-spin 0.7s linear infinite;
-    }
-
-    @keyframes slot-spin { to { transform: rotate(360deg); } }
-
-    .slot-push-loading {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      min-height: 220px;
-      padding: 2rem;
-    }
-
-    .slot-spinner-large {
-      width: 80px;
-      height: 80px;
-      border: 6px solid #e0e0e0;
-      border-top-color: var(--color-accent);
-      border-radius: 50%;
-      animation: slot-spin 0.7s linear infinite;
-    }
-
-    .push-result-center {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      min-height: 220px;
-      padding: 2rem;
-      text-align: center;
-    }
-
-    .push-check-svg { width: 80px; height: 80px; margin-bottom: 1.25rem; }
-
-    .push-check-circle {
-      stroke: var(--color-accent);
-      stroke-width: 2;
-      stroke-dasharray: 166;
-      stroke-dashoffset: 166;
-      stroke-miterlimit: 10;
-      animation: push-stroke 0.6s cubic-bezier(0.65, 0, 0.45, 1) forwards;
-    }
-
-    .push-check-mark {
-      stroke: var(--color-accent);
-      stroke-width: 3;
-      stroke-linecap: round;
-      stroke-linejoin: round;
-      stroke-dasharray: 48;
-      stroke-dashoffset: 48;
-      animation: push-stroke 0.3s cubic-bezier(0.65, 0, 0.45, 1) 0.6s forwards;
-    }
-
-    @keyframes push-stroke { 100% { stroke-dashoffset: 0; } }
-
-    .push-result-message { font-size: 1.3rem; font-weight: 700; color: #222; }
-
-    .push-result-err-message {
-      font-size: 1rem;
-      color: #dc2626;
-      margin-bottom: 1.5rem;
-      line-height: 1.5;
-    }
-
-    .push-retry-btn {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0.75rem 1.5rem;
-      border: 1.5px solid var(--color-accent);
-      border-radius: 12px;
-      background: white;
-      color: var(--color-accent);
-      font-size: 0.95rem;
-      font-weight: 600;
-      cursor: pointer;
-      transition: background 0.15s;
-    }
-
-    .push-retry-btn:hover { background: var(--color-accent-light); }
   </style>
 </head>
 <body>
@@ -518,7 +400,6 @@
 <div id="detail-overlay">
   {% include "images/_image_detail_partial.html" %}
 </div>
-<div id="slot-overlay" hidden></div>
 
 <script>
   function initRecipeSelects() {
@@ -653,30 +534,6 @@
     history.replaceState(null, '', '/images/' + (params.toString() ? '?' + params.toString() : ''));
   };
 
-  function closeSlotOverlay() {
-    document.getElementById('slot-overlay').hidden = true;
-  }
-
-  var _slotSpinnerHTML = '<div class="slot-card slot-card--loading"><div class="slot-spinner"></div></div>';
-  var _slotPushLoadingHTML = '<div class="slot-push-loading"><div class="slot-spinner-large"></div></div>';
-
-  document.body.addEventListener('htmx:beforeRequest', function (e) {
-    if (e.detail.target && e.detail.target.id === 'slot-overlay') {
-      var overlay = document.getElementById('slot-overlay');
-      overlay.innerHTML = _slotSpinnerHTML;
-      overlay.hidden = false;
-    }
-    if (e.detail.target && e.detail.target.id === 'slot-card') {
-      e.detail.target.innerHTML = _slotPushLoadingHTML;
-    }
-  });
-
-  document.body.addEventListener('htmx:afterSwap', function (e) {
-    if (e.detail.target.id === 'slot-overlay') {
-      e.detail.target.hidden = false;
-    }
-  });
-
   document.body.addEventListener('htmx:beforeHistoryUpdate', function (e) {
     if (e.detail.target && e.detail.target.id === 'detail-overlay') {
       var params = new URLSearchParams(window.location.search);
@@ -686,15 +543,7 @@
     }
   });
 
-  document.getElementById('slot-overlay').addEventListener('click', function (e) {
-    if (e.target === this) closeSlotOverlay();
-  });
-
   document.addEventListener('keydown', function (e) {
-    if (e.key === 'Escape') {
-      var slotOverlay = document.getElementById('slot-overlay');
-      if (slotOverlay && !slotOverlay.hidden) { closeSlotOverlay(); return; }
-    }
     var overlay = document.getElementById('detail-overlay');
     if (!overlay || overlay.hidden) return;
     if (e.key === 'Escape') window.closeImageDetail();

--- a/src/interfaces/templates/recipes/partials/recipe_detail.html
+++ b/src/interfaces/templates/recipes/partials/recipe_detail.html
@@ -299,27 +299,48 @@
   .settings-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 0 2.5rem;
+    gap: 1.75rem 2.5rem;
   }
 
+  /* The column wrappers collapse so the sections become grid items directly.
+     Pairing them onto explicit rows makes each row as tall as the taller of
+     its two sections, so the pairs stay level across columns (Grain with
+     Dynamic Range, White Balance with Color Chrome) however tall either side
+     grows -- the camera badges, for instance, reserve extra height for their
+     overflow peek. */
+  .settings-grid > div { display: contents; }
+
+  .settings-grid .settings-section { margin-bottom: 0; }
+
+  .settings-section--basic         { grid-column: 1; grid-row: 1; }
+  .settings-section--grain         { grid-column: 1; grid-row: 2; }
+  .settings-section--white-balance { grid-column: 1; grid-row: 3; }
+  .settings-section--camera        { grid-column: 2; grid-row: 1; }
+  .settings-section--dynamic-range { grid-column: 2; grid-row: 2; }
+
+  /* Color Chrome and BW Tone share the cell opposite White Balance, so BW Tone
+     follows straight on from Color Chrome rather than being pushed below the
+     tall white-balance grid. */
+  .settings-cell--chrome-tone {
+    grid-column: 2;
+    grid-row: 3;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+  }
+
+  /* Separated from the grid above by the same gap that separates its rows, so
+     whichever section ends each column (White Balance, Color Chrome or BW
+     Tone) keeps its distance from Tone & Color and Detail. */
   .settings-bottom {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 0 2.5rem;
-    margin-top: 0.25rem;
+    margin-top: 1.75rem;
   }
 
   .settings-section {
     margin-bottom: 1.75rem;
-  }
-
-  /* The two camera-rows are taller than their settings-row counterparts in
-     the opposite column (the badge container reserves vertical space for an
-     overflow peek), so this section absorbs the extra height by giving up
-     some bottom margin -- keeping the next sections (Dynamic Range, Color
-     Chrome) aligned horizontally with Grain and White Balance across columns. */
-  .settings-section--camera {
-    margin-bottom: 0.6rem;
   }
 
   .settings-section-header {
@@ -436,45 +457,33 @@
     white-space: nowrap;
   }
 
-  /* WB color grid (read-only) */
-  .wb-grid-readonly-outer {
+  /* WB color grid (read-only) on the left, the white-balance values beside it.
+     The values start at the top, so they line up with the Color Chrome rows
+     opposite them; the grid gets room below so it does not crowd the section
+     underneath. */
+  .wb-layout {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
-    padding: 0.75rem 0.75rem 0.25rem;
+    align-items: flex-start;
+    gap: 1.5rem;
+    padding-bottom: 1.25rem;
   }
 
-  .wb-grid-readonly-legend {
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-    white-space: nowrap;
+  /* Line the grid up with the properties beside it: indented to where their
+     names start (past the row's own indent and the label icon), and dropped by
+     the row's top padding so its top edge meets the first property rather than
+     floating above it. */
+  .wb-layout > .wb-grid-readonly-wrap {
+    margin-left: calc(0.75rem + 13px + 6px);
+    margin-top: 0.4rem;
   }
 
-  .wb-legend-line {
-    display: flex;
-    align-items: center;
-    gap: 6px;
+  .wb-layout__values {
+    flex: 1;
+    min-width: 0;
   }
 
-  .wb-legend-label {
-    font-size: 0.82rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: #9ca3af;
-  }
-
-  .wb-legend-value {
-    font-size: 0.9rem;
-    font-weight: 700;
-    font-family: monospace;
-    letter-spacing: 0.06em;
-  }
-
-  .wb-legend-value--red  { color: var(--color-accent); }
-  .wb-legend-value--blue { color: #2563eb; }
+  .settings-row-value--red  { color: var(--color-accent); }
+  .settings-row-value--blue { color: #2563eb; }
 
   .wb-grid-readonly-wrap {
     display: grid;
@@ -482,6 +491,7 @@
     grid-template-rows: repeat(19, 8px);
     gap: 1px;
     line-height: 0;
+    flex-shrink: 0;
   }
 
   .wb-dot {
@@ -547,7 +557,7 @@
           {# LEFT COLUMN: BASIC · GRAIN · WHITE BALANCE #}
           <div>
 
-            <div class="settings-section">
+            <div class="settings-section settings-section--basic">
               <div class="settings-section-header">Basic</div>
               <div class="settings-row">
                 <span class="settings-row-label">
@@ -576,7 +586,7 @@
               </div>
             </div>
 
-            <div class="settings-section">
+            <div class="settings-section settings-section--grain">
               <div class="settings-section-header">Grain</div>
               <div class="settings-row">
                 <span class="settings-row-label">
@@ -605,43 +615,46 @@
               </div>
             </div>
 
-            <div class="settings-section">
+            <div class="settings-section settings-section--white-balance">
               <div class="settings-section-header">White Balance</div>
-              <div class="settings-row">
-                <span class="settings-row-label">
-                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M5 9.5 C5 9.5 3.2 8.3 3.2 6.2 A3.8 3.8 0 0 1 10.8 6.2 C10.8 8.3 9 9.5 9 9.5 Z"/>
-                    <line x1="5.2" y1="11" x2="8.8" y2="11"/>
-                    <line x1="5.8" y1="12.5" x2="8.2" y2="12.5"/>
-                  </svg>
-                  White Balance
-                </span>
-                <span class="settings-row-value">{{ recipe.white_balance }}</span>
-              </div>
-              {# WB Red/Blue shifts are read off the grid below; no need for separate text rows. #}
-              <div class="wb-grid-readonly-outer">
+              <div class="wb-layout">
                 <div class="wb-grid-readonly-wrap"
                      data-r="{{ recipe.white_balance_red }}"
                      data-b="{{ recipe.white_balance_blue }}"></div>
-                <div class="wb-grid-readonly-legend">
-                  <span class="wb-legend-line">
-                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
-                      <line x1="2" y1="7" x2="11" y2="7"/>
-                      <polyline points="8.5,4.5 11,7 8.5,9.5"/>
-                      <text x="1" y="12" font-size="5" fill="currentColor" stroke="none" font-weight="700" font-family="sans-serif">R</text>
-                    </svg>
-                    <span class="wb-legend-label">Red</span>
-                    <span class="wb-legend-value wb-legend-value--red">{{ recipe.white_balance_red|signed }}</span>
-                  </span>
-                  <span class="wb-legend-line">
-                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
-                      <line x1="2" y1="7" x2="11" y2="7"/>
-                      <polyline points="8.5,4.5 11,7 8.5,9.5"/>
-                      <text x="1" y="12" font-size="5" fill="currentColor" stroke="none" font-weight="700" font-family="sans-serif">B</text>
-                    </svg>
-                    <span class="wb-legend-label">Blue</span>
-                    <span class="wb-legend-value wb-legend-value--blue">{{ recipe.white_balance_blue|signed }}</span>
-                  </span>
+                <div class="wb-layout__values">
+                  <div class="settings-row">
+                    <span class="settings-row-label">
+                      <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M5 9.5 C5 9.5 3.2 8.3 3.2 6.2 A3.8 3.8 0 0 1 10.8 6.2 C10.8 8.3 9 9.5 9 9.5 Z"/>
+                        <line x1="5.2" y1="11" x2="8.8" y2="11"/>
+                        <line x1="5.8" y1="12.5" x2="8.2" y2="12.5"/>
+                      </svg>
+                      White Balance
+                    </span>
+                    <span class="settings-row-value">{{ recipe.white_balance }}</span>
+                  </div>
+                  <div class="settings-row">
+                    <span class="settings-row-label">
+                      <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+                        <line x1="2" y1="7" x2="11" y2="7"/>
+                        <polyline points="8.5,4.5 11,7 8.5,9.5"/>
+                        <text x="1" y="12" font-size="5" fill="currentColor" stroke="none" font-weight="700" font-family="sans-serif">R</text>
+                      </svg>
+                      Red
+                    </span>
+                    <span class="settings-row-value settings-row-value--red">{{ recipe.white_balance_red|signed }}</span>
+                  </div>
+                  <div class="settings-row">
+                    <span class="settings-row-label">
+                      <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+                        <line x1="2" y1="7" x2="11" y2="7"/>
+                        <polyline points="8.5,4.5 11,7 8.5,9.5"/>
+                        <text x="1" y="12" font-size="5" fill="currentColor" stroke="none" font-weight="700" font-family="sans-serif">B</text>
+                      </svg>
+                      Blue
+                    </span>
+                    <span class="settings-row-value settings-row-value--blue">{{ recipe.white_balance_blue|signed }}</span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -694,7 +707,7 @@
               </div>
             </div>
 
-            <div class="settings-section">
+            <div class="settings-section settings-section--dynamic-range">
               <div class="settings-section-header">Dynamic Range</div>
               <div class="settings-row">
                 <span class="settings-row-label">
@@ -721,59 +734,63 @@
               </div>
             </div>
 
-            <div class="settings-section">
-              <div class="settings-section-header">Color Chrome</div>
-              <div class="settings-row">
-                <span class="settings-row-label">
-                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
-                    <polygon points="7,1 13,12 1,12"/>
-                    <line x1="7" y1="1" x2="4" y2="7" stroke-width="0.8" opacity="0.5"/>
-                    <line x1="7" y1="1" x2="7.5" y2="5.5" stroke-width="0.8" opacity="0.5"/>
-                    <line x1="7" y1="1" x2="10.5" y2="8" stroke-width="0.8" opacity="0.5"/>
-                  </svg>
-                  Color Chrome Effect
-                </span>
-                <span class="settings-row-value">{{ recipe.color_chrome_effect }}</span>
-              </div>
-              <div class="settings-row">
-                <span class="settings-row-label">
-                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
-                    <circle cx="7" cy="7" r="5.5"/>
-                    <circle cx="7" cy="7" r="2" fill="currentColor" stroke="none" opacity="0.6"/>
-                  </svg>
-                  Color Chrome FX Blue
-                </span>
-                <span class="settings-row-value">{{ recipe.color_chrome_fx_blue }}</span>
-              </div>
-            </div>
+            <div class="settings-cell--chrome-tone">
 
-            {% if is_monochromatic %}
-            <div class="settings-section">
-              <div class="settings-section-header">BW Tone</div>
-              <div class="settings-row">
-                <span class="settings-row-label">
-                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
-                    <line x1="1" y1="7" x2="13" y2="7"/>
-                    <polyline points="4,4.5 1,7 4,9.5"/>
-                    <polyline points="10,4.5 13,7 10,9.5"/>
-                  </svg>
-                  BW Warm / Cool
-                </span>
-                <span class="settings-row-value">{{ recipe.monochromatic_color_warm_cool|signed }}</span>
+              <div class="settings-section">
+                <div class="settings-section-header">Color Chrome</div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
+                      <polygon points="7,1 13,12 1,12"/>
+                      <line x1="7" y1="1" x2="4" y2="7" stroke-width="0.8" opacity="0.5"/>
+                      <line x1="7" y1="1" x2="7.5" y2="5.5" stroke-width="0.8" opacity="0.5"/>
+                      <line x1="7" y1="1" x2="10.5" y2="8" stroke-width="0.8" opacity="0.5"/>
+                    </svg>
+                    Color Chrome Effect
+                  </span>
+                  <span class="settings-row-value">{{ recipe.color_chrome_effect }}</span>
+                </div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+                      <circle cx="7" cy="7" r="5.5"/>
+                      <circle cx="7" cy="7" r="2" fill="currentColor" stroke="none" opacity="0.6"/>
+                    </svg>
+                    Color Chrome FX Blue
+                  </span>
+                  <span class="settings-row-value">{{ recipe.color_chrome_fx_blue }}</span>
+                </div>
               </div>
-              <div class="settings-row">
-                <span class="settings-row-label">
-                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
-                    <line x1="7" y1="1" x2="7" y2="13"/>
-                    <polyline points="4.5,4 7,1 9.5,4"/>
-                    <polyline points="4.5,10 7,13 9.5,10"/>
-                  </svg>
-                  BW Magenta / Green
-                </span>
-                <span class="settings-row-value">{{ recipe.monochromatic_color_magenta_green|signed }}</span>
+
+              {% if is_monochromatic %}
+              <div class="settings-section">
+                <div class="settings-section-header">BW Tone</div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
+                      <line x1="1" y1="7" x2="13" y2="7"/>
+                      <polyline points="4,4.5 1,7 4,9.5"/>
+                      <polyline points="10,4.5 13,7 10,9.5"/>
+                    </svg>
+                    BW Warm / Cool
+                  </span>
+                  <span class="settings-row-value">{{ recipe.monochromatic_color_warm_cool|signed }}</span>
+                </div>
+                <div class="settings-row">
+                  <span class="settings-row-label">
+                    <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
+                      <line x1="7" y1="1" x2="7" y2="13"/>
+                      <polyline points="4.5,4 7,1 9.5,4"/>
+                      <polyline points="4.5,10 7,13 9.5,10"/>
+                    </svg>
+                    BW Magenta / Green
+                  </span>
+                  <span class="settings-row-value">{{ recipe.monochromatic_color_magenta_green|signed }}</span>
+                </div>
               </div>
-            </div>
-            {% endif %}
+              {% endif %}
+
+            </div>{# /.settings-cell--chrome-tone #}
 
           </div>{# /right column #}
 

--- a/src/interfaces/templates/recipes/partials/recipe_detail.html
+++ b/src/interfaces/templates/recipes/partials/recipe_detail.html
@@ -882,6 +882,7 @@
         {% if recipe.image_count %}
           <a class="action-btn action-btn--secondary" href="{% url 'gallery' %}?recipe_id={{ recipe.id }}">Browse {{ recipe.image_count }} image{{ recipe.image_count|pluralize }}</a>
         {% endif %}
+        <a class="action-btn action-btn--secondary" href="{% url 'recipe-graph' recipe_id=recipe.id %}">View in graph</a>
         <button class="action-btn action-btn--secondary"
                 hx-get="{% url 'recipe-card-modal' recipe_id=recipe.id %}"
                 hx-target="#card-overlay"

--- a/src/interfaces/templates/recipes/recipe_graph.html
+++ b/src/interfaces/templates/recipes/recipe_graph.html
@@ -255,7 +255,10 @@
     <div class="recipe-card" id="recipe-card">
       <div class="recipe-card__section" id="card-root-section">
         <div class="recipe-card__title">Recipe of Reference</div>
-        <div class="recipe-card__name" id="card-root-name"></div>
+        <div class="recipe-card__name-row">
+          <div class="recipe-card__name" id="card-root-name"></div>
+          <button class="recipe-card__btn" id="card-root-detail-btn">View recipe</button>
+        </div>
         <div class="recipe-card__fields recipe-card__fields--two-col" id="card-root-fields"></div>
       </div>
       <div id="card-selected-section" style="display:none">
@@ -557,6 +560,12 @@
   }
 
   populateRootCard(ROOT_LABEL, ROOT_FIELDS);
+
+  // Reads ROOT_ID at click time so it stays correct after the film-sim
+  // filter re-roots the graph.
+  document.getElementById("card-root-detail-btn").onclick = function () {
+    window.location.href = "/recipes/" + ROOT_ID + "/";
+  };
 
   // BFS path from rootId to targetId using graph edges
   function findPath(rootId, targetId) {

--- a/src/interfaces/templates/recipes/recipes_graph.html
+++ b/src/interfaces/templates/recipes/recipes_graph.html
@@ -284,7 +284,10 @@
     <div class="recipe-card" id="recipe-card">
       <div class="recipe-card__section" id="card-root-section">
         <div class="recipe-card__title">Recipe of Reference</div>
-        <div class="recipe-card__name" id="card-root-name"></div>
+        <div class="recipe-card__name-row">
+          <div class="recipe-card__name" id="card-root-name"></div>
+          <button class="recipe-card__btn" id="card-root-detail-btn">View recipe</button>
+        </div>
         <div class="recipe-card__fields recipe-card__fields--two-col" id="card-root-fields"></div>
       </div>
       <div id="card-selected-section" style="display:none">
@@ -593,6 +596,12 @@
   }
 
   populateRootCard(ROOT_LABEL, ROOT_FIELDS);
+
+  // Reads ROOT_ID at click time so it stays correct after the film-sim
+  // filter re-roots the graph.
+  document.getElementById("card-root-detail-btn").onclick = function () {
+    window.location.href = "/recipes/" + ROOT_ID + "/";
+  };
 
   // BFS path from rootId to targetId using graph edges
   function findPath(rootId, targetId) {

--- a/tests/functional/test_image_detail_view.py
+++ b/tests/functional/test_image_detail_view.py
@@ -187,3 +187,17 @@ class TestImageDetailRecipeSection:
         response = self._get_partial(client, image.id)
         soup = BeautifulSoup(response.content, "html.parser")
         assert soup.find(class_="send-to-camera-btn") is None
+
+    def test_shows_bw_tone_section_for_monochromatic_recipe(self, client):
+        recipe = FujifilmRecipeFactory(film_simulation="Acros STD")
+        image = ImageFactory(fujifilm_recipe=recipe)
+        response = self._get_partial(client, image.id)
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="settings-section--bw-tone") is not None
+
+    def test_hides_bw_tone_section_for_color_recipe(self, client):
+        recipe = FujifilmRecipeFactory(film_simulation="Provia")
+        image = ImageFactory(fujifilm_recipe=recipe)
+        response = self._get_partial(client, image.id)
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="settings-section--bw-tone") is None

--- a/tests/functional/test_image_detail_view.py
+++ b/tests/functional/test_image_detail_view.py
@@ -148,78 +148,42 @@ class TestGalleryThumbnailsLinkToDetail:
 
 
 @pytest.mark.django_db
-class TestImageDetailRecipeNamePrompt:
+class TestImageDetailRecipeSection:
     def _get_partial(self, client, image_id):
         return client.get(f"/images/{image_id}/", HTTP_HX_REQUEST="true")
 
-    def test_shows_name_this_recipe_button_when_recipe_has_no_name(self, client):
-        recipe = FujifilmRecipeFactory(name="")
+    def test_links_to_recipe_detail_when_image_has_recipe(self, client):
+        recipe = FujifilmRecipeFactory(name="Cuban Negative")
         image = ImageFactory(fujifilm_recipe=recipe)
         response = self._get_partial(client, image.id)
         soup = BeautifulSoup(response.content, "html.parser")
-        assert soup.find(class_="name-recipe-btn") is not None
+        link = soup.find("a", class_="view-recipe-btn")
+        assert link is not None
+        assert link["href"] == f"/recipes/{recipe.id}/"
 
-    def test_hides_name_this_recipe_button_when_recipe_has_name(self, client):
-        recipe = FujifilmRecipeFactory(name="My Recipe")
+    def test_shows_no_view_recipe_link_when_image_has_no_recipe(self, client):
+        image = ImageFactory(fujifilm_recipe=None)
+        response = self._get_partial(client, image.id)
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find("a", class_="view-recipe-btn") is None
+
+    def test_shows_recipe_name_when_named(self, client):
+        recipe = FujifilmRecipeFactory(name="Cuban Negative")
+        image = ImageFactory(fujifilm_recipe=recipe)
+        response = self._get_partial(client, image.id)
+        assert b"Cuban Negative" in response.content
+
+    def test_offers_no_inline_recipe_naming(self, client):
+        recipe = FujifilmRecipeFactory(name="")
         image = ImageFactory(fujifilm_recipe=recipe)
         response = self._get_partial(client, image.id)
         soup = BeautifulSoup(response.content, "html.parser")
         assert soup.find(class_="name-recipe-btn") is None
+        assert soup.find(id=f"recipe-name-prompt-{recipe.id}") is None
 
-    def test_name_form_posts_to_set_recipe_name_url(self, client):
-        recipe = FujifilmRecipeFactory(name="")
-        image = ImageFactory(fujifilm_recipe=recipe)
-        response = self._get_partial(client, image.id)
-        soup = BeautifulSoup(response.content, "html.parser")
-        form = soup.find(id=f"recipe-name-prompt-{recipe.id}")
-        assert form is not None
-        assert form["hx-post"] == f"/recipes/{recipe.id}/set-name/"
-
-    def test_no_name_prompt_when_no_recipe(self, client):
-        image = ImageFactory(fujifilm_recipe=None)
-        response = self._get_partial(client, image.id)
-        soup = BeautifulSoup(response.content, "html.parser")
-        assert soup.find(class_="name-recipe-btn") is None
-
-
-@pytest.mark.django_db
-class TestImageDetailPartialSendToCamera:
-    def _get_partial(self, client, image_id):
-        return client.get(f"/images/{image_id}/", HTTP_HX_REQUEST="true")
-
-    def test_send_to_camera_button_present_when_recipe_has_name(self, client):
+    def test_offers_no_inline_send_to_camera(self, client):
         recipe = FujifilmRecipeFactory(name="Cuban Negative")
         image = ImageFactory(fujifilm_recipe=recipe)
-
         response = self._get_partial(client, image.id)
-
-        soup = BeautifulSoup(response.content, "html.parser")
-        btn = soup.find(class_="send-to-camera-btn")
-        assert btn is not None
-
-    def test_send_to_camera_button_points_to_select_slot_url(self, client):
-        recipe = FujifilmRecipeFactory(name="Cuban Negative")
-        image = ImageFactory(fujifilm_recipe=recipe)
-
-        response = self._get_partial(client, image.id)
-
-        soup = BeautifulSoup(response.content, "html.parser")
-        btn = soup.find(class_="send-to-camera-btn")
-        assert btn["hx-get"] == f"/recipes/{recipe.id}/push/"
-
-    def test_send_to_camera_button_absent_when_recipe_has_no_name(self, client):
-        recipe = FujifilmRecipeFactory(name="")
-        image = ImageFactory(fujifilm_recipe=recipe)
-
-        response = self._get_partial(client, image.id)
-
-        soup = BeautifulSoup(response.content, "html.parser")
-        assert soup.find(class_="send-to-camera-btn") is None
-
-    def test_send_to_camera_button_absent_when_no_recipe(self, client):
-        image = ImageFactory(fujifilm_recipe=None)
-
-        response = self._get_partial(client, image.id)
-
         soup = BeautifulSoup(response.content, "html.parser")
         assert soup.find(class_="send-to-camera-btn") is None


### PR DESCRIPTION
Recipes, graphs and images were all reachable from the nav but not from each
other. This wires them together, and tidies up the recipe panels along the way.

### Page connections
- Recipe detail → **"View in graph"** button, opening the graph centred on that recipe.
- Recipe graph → **"View recipe"** button in the *Recipe of Reference* panel, on both
  the all-recipes and single-recipe graphs. Follows the film-sim filter when it re-roots.
- Image detail → **"View recipe"** link from the Fujifilm Recipe section.

### Image detail
- Removed the inline recipe naming and *Send to camera* controls. both now
  live on the recipe page, one click away. This also let us delete the duplicated
  slot-overlay/push-result plumbing from `gallery.html` and `image_detail.html` (~300 lines).
- Recipe properties are now grouped into titled sections across two columns, with icons,
  in the same order as the recipe detail view. 
- Added a **BW Tone** section for monochromatic recipes.
- Redesigned the action buttons.

### Recipe detail
- Settings sections now align across columns. 
- White balance reworked.

### Notes
- No behaviour change to the push-to-camera flow itself — it still lives on the recipe
  explorer.
