### PR TITLE
Bulk rate images from the gallery multi-select

### DIFF
--- a/docs/web_interface.md
+++ b/docs/web_interface.md
@@ -58,6 +58,17 @@ A **Clear all filters** link at the top of the sidebar resets everything in one 
 You can also enable **Rating first** to sort the grid by rating (highest first), so your
 best-rated images always appear at the top.
 
+#### Bulk actions
+
+The gallery supports **multi-select mode** for acting on several images at once. Click any
+image card's checkbox (or click a card while another is already selected) to enter selection
+mode, then open the _Actions_ menu to choose what to do with the selection.
+
+- **Set rating** — a modal shows how many images are selected and the same star widget used
+  in the image detail view. Pick a rating (or the ✕ to clear it) and confirm to apply it to
+  every selected image at once. The gallery reloads when you close the modal so the updated
+  star counts appear on the cards.
+
 ---
 
 ### Image Detail

--- a/src/application/usecases/images/set_images_rating.py
+++ b/src/application/usecases/images/set_images_rating.py
@@ -1,0 +1,38 @@
+from collections.abc import Sequence
+
+import attrs
+
+from src.domain.images import operations as image_operations
+
+
+@attrs.frozen
+class InvalidRatingError(Exception):
+    """
+    Raised when the requested rating is outside the allowed range.
+    """
+
+    rating: int
+
+
+@attrs.frozen
+class SetImagesRatingResult:
+    rated_count: int
+    requested_count: int
+
+    @property
+    def not_found_count(self) -> int:
+        return self.requested_count - self.rated_count
+
+
+def set_images_rating(*, image_ids: Sequence[int], rating: int) -> SetImagesRatingResult:
+    """
+    Set *rating* on every image in *image_ids*.
+
+    Raises:
+        InvalidRatingError: If *rating* is outside the allowed range.
+    """
+    try:
+        rated_count = image_operations.set_images_rating(image_ids=image_ids, rating=rating)
+    except image_operations.InvalidImageRatingError as exc:
+        raise InvalidRatingError(rating=exc.rating) from exc
+    return SetImagesRatingResult(rated_count=rated_count, requested_count=len(image_ids))

--- a/src/domain/images/operations.py
+++ b/src/domain/images/operations.py
@@ -1,6 +1,7 @@
-import attrs
 import os
+from collections.abc import Sequence
 
+import attrs
 from django import conf
 from django.db import transaction
 
@@ -44,6 +45,36 @@ def set_image_rating(*, image: models.Image, rating: int) -> None:
         image_id=image.pk,
         rating=rating,
     )
+
+
+def set_images_rating(*, image_ids: Sequence[int], rating: int) -> int:
+    """
+    Set the rating of every image in *image_ids* to *rating* in a single bulk update.
+
+    Publishes one IMAGE_RATING_SET event per image that is actually updated;
+    ids that do not exist are skipped and get no event. Returns the number of
+    images updated.
+
+    Raises:
+        InvalidImageRatingError: If *rating* is negative or exceeds
+            settings.IMAGE_MAX_RATING.
+    """
+    if rating < 0 or rating > conf.settings.IMAGE_MAX_RATING:
+        raise InvalidImageRatingError(rating)
+
+    with transaction.atomic():
+        images = models.Image.objects.filter(pk__in=image_ids)
+        updated_ids = list(images.values_list("pk", flat=True))
+        images.update(rating=rating)
+
+    for image_id in updated_ids:
+        events.publish_event(
+            event_type=events.IMAGE_RATING_SET,
+            image_id=image_id,
+            rating=rating,
+        )
+
+    return len(updated_ids)
 
 
 def rate_image(*, image_path: str, rating: int) -> models.Image:

--- a/src/interfaces/images/urls.py
+++ b/src/interfaces/images/urls.py
@@ -5,6 +5,7 @@ from src.interfaces.images import views
 urlpatterns = [
     path("images/", views.Gallery.as_view(), name="gallery"),
     path("images/results/", views.GalleryResults.as_view(), name="gallery-results"),
+    path("images/set-rating/", views.SetImagesRating.as_view(), name="images-set-rating"),
     path("images/file/<int:image_id>/", views.ImageFile.as_view(), name="image-file"),
     path("images/<int:image_id>/", views.ImageDetail.as_view(), name="image-detail"),
     path("images/<int:image_id>/set-rating/", views.SetImageRating.as_view(), name="image-set-rating"),

--- a/src/interfaces/images/views.py
+++ b/src/interfaces/images/views.py
@@ -1,12 +1,14 @@
 import mimetypes
 from pathlib import Path
 
+import structlog
 from django.conf import settings
 from django.core import paginator as django_paginator
 from django import http
 from django import shortcuts
 from django.views import generic
 
+from src.application.usecases.images import set_images_rating as set_images_rating_uc
 from src.data import models
 from src.domain.images import filter_queries
 from src.domain.images import operations as image_operations
@@ -49,6 +51,7 @@ class Gallery(generic.View):
                 "sidebar_options": gallery.sidebar_options,
                 "recipe_options": gallery.recipe_options,
             })
+        max_rating = settings.IMAGE_MAX_RATING
         return shortcuts.render(
             request,
             "images/gallery.html",
@@ -57,6 +60,8 @@ class Gallery(generic.View):
                 "sidebar_options": gallery.sidebar_options,
                 "recipe_options": gallery.recipe_options,
                 "rating_first": "1" if rating_first else "0",
+                "max_rating": max_rating,
+                "rating_range": range(1, max_rating + 1),
             },
         )
 
@@ -182,6 +187,51 @@ class SetImageRating(generic.View):
                 "rating": self.image.rating,
                 "max_rating": max_rating,
                 "rating_range": range(1, max_rating + 1),
+            },
+        )
+
+
+class SetImagesRating(generic.View):
+    """
+    Set the same star rating on a batch of selected images.
+
+    Returns an HTML result fragment for the multi-select modal.
+    """
+
+    def post(self, request: http.HttpRequest) -> http.HttpResponse:
+        image_ids_raw = request.POST.getlist("image_ids")
+        try:
+            image_ids = [int(pk) for pk in image_ids_raw]
+        except (ValueError, TypeError):
+            return http.HttpResponseBadRequest("image_ids must be integers")
+        try:
+            rating = int(request.POST["rating"])
+        except (KeyError, ValueError, TypeError):
+            return http.HttpResponseBadRequest("rating must be an integer")
+
+        try:
+            result = set_images_rating_uc.set_images_rating(image_ids=image_ids, rating=rating)
+        except set_images_rating_uc.InvalidRatingError:
+            return shortcuts.render(
+                request,
+                "images/partials/set_images_rating_result.html",
+                {"error": "That rating is not allowed. Please try again."},
+            )
+        except Exception:
+            structlog.get_logger().exception("Unexpected error in SetImagesRating.post")
+            return shortcuts.render(
+                request,
+                "images/partials/set_images_rating_result.html",
+                {"error": "An unexpected error occurred. Please try again."},
+            )
+        return shortcuts.render(
+            request,
+            "images/partials/set_images_rating_result.html",
+            {
+                "rated_count": result.rated_count,
+                "not_found_count": result.not_found_count,
+                "rating": rating,
+                "all_succeeded": result.not_found_count == 0,
             },
         )
 

--- a/src/interfaces/templates/images/_rating_picker.html
+++ b/src/interfaces/templates/images/_rating_picker.html
@@ -1,0 +1,6 @@
+<div class="detail-rating" id="set-rating-picker">
+  <button type="button" class="detail-rating-clear" data-rating="0" title="Clear rating">&#x2715;</button>
+  {% for i in rating_range %}
+    <button type="button" class="detail-rating-star" data-rating="{{ i }}" title="Rate {{ i }}/{{ max_rating }}">&#x2605;</button>
+  {% endfor %}
+</div>

--- a/src/interfaces/templates/images/gallery.html
+++ b/src/interfaces/templates/images/gallery.html
@@ -379,6 +379,148 @@
     #detail-overlay .detail-overlay {
       height: 100%;
     }
+
+    /* Multi-select action dropdown option */
+    .ms-actions-option {
+      display: block;
+      width: 100%;
+      padding: 0.65rem 1rem;
+      background: none;
+      border: none;
+      text-align: left;
+      font-size: 0.875rem;
+      color: #333;
+      cursor: pointer;
+    }
+    .ms-actions-option:hover { background: #f5f5f5; }
+
+    /* Set-rating modal (shared shell also used by the recipes explorer) */
+    .import-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.45);
+      z-index: 200;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .import-overlay[hidden] { display: none; }
+    .import-modal {
+      background: #fff;
+      border-radius: 10px;
+      padding: 2rem;
+      width: 480px;
+      max-width: calc(100vw - 2rem);
+      max-height: calc(100vh - 4rem);
+      overflow-y: auto;
+      position: relative;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+    }
+    .import-modal__close {
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      background: none;
+      border: none;
+      font-size: 1.4rem;
+      color: #888;
+      cursor: pointer;
+      line-height: 1;
+      padding: 0.2rem 0.4rem;
+    }
+    .import-modal__close:hover { color: #333; }
+    .import-modal h2 {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #222;
+      margin-bottom: 0.5rem;
+    }
+    .import-modal__desc {
+      font-size: 0.875rem;
+      color: #666;
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+    .delete-confirm__actions {
+      display: flex;
+      gap: 0.75rem;
+      justify-content: flex-end;
+      margin-top: 1.5rem;
+    }
+    .delete-confirm__no-btn {
+      padding: 0.5rem 1.25rem;
+      background: none;
+      border: 1px solid #ccc;
+      border-radius: 5px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #555;
+      cursor: pointer;
+    }
+    .delete-confirm__no-btn:hover { background: #f0f0f0; }
+    .delete-confirm__yes-btn {
+      padding: 0.5rem 1.25rem;
+      background: var(--color-accent);
+      border: none;
+      border-radius: 5px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #fff;
+      cursor: pointer;
+    }
+    .delete-confirm__yes-btn:hover { background: var(--color-accent-dark); }
+    .delete-confirm__yes-btn:disabled { background: #ccc; cursor: not-allowed; }
+
+    .remove-result { margin-top: 1.25rem; }
+    .remove-result__message { font-size: 0.875rem; margin-bottom: 0.35rem; }
+    .remove-result__message--success { color: var(--color-accent); font-weight: 600; }
+    .remove-result__message--warning { color: #b36b2d; font-weight: 600; }
+    .remove-result--error .remove-result__message { color: #c0392b; }
+
+    /* Star picker inside the set-rating modal (light background variant) */
+    .set-rating-modal__picker {
+      display: flex;
+      justify-content: center;
+      margin: 0.5rem 0 0.5rem;
+    }
+    .set-rating-modal__picker .detail-rating {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.15rem;
+    }
+    .set-rating-modal__picker .detail-rating-star {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.4rem;
+      height: 2.4rem;
+      border-radius: 50%;
+      background: transparent;
+      color: #d0d0d0;
+      font-size: 1.6rem;
+      border: none;
+      cursor: pointer;
+      transition: color 0.15s;
+      line-height: 1;
+    }
+    .set-rating-modal__picker .detail-rating-star:hover,
+    .set-rating-modal__picker .detail-rating-star--active { color: #f5c518; }
+    .set-rating-modal__picker .detail-rating-clear {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.8rem;
+      height: 1.8rem;
+      border-radius: 50%;
+      background: transparent;
+      color: #c0c0c0;
+      font-size: 0.95rem;
+      border: none;
+      cursor: pointer;
+      margin-right: 0.15rem;
+      transition: color 0.15s;
+    }
+    .set-rating-modal__picker .detail-rating-clear:hover { color: #666; }
   </style>
 </head>
 <body>
@@ -419,7 +561,7 @@
           </svg>
         </button>
         <div class="ms-actions-dropdown" id="ms-actions-dropdown" hidden>
-          <span class="ms-actions-empty">No actions available yet</span>
+          <button class="ms-actions-option" id="ms-set-rating-btn" type="button">Set rating</button>
         </div>
       </div>
     </div>
@@ -466,6 +608,115 @@
 </script>
 
 <div id="detail-overlay" hidden></div>
+
+<!-- Set rating modal -->
+<div class="import-overlay" id="set-rating-overlay" hidden>
+  <div class="import-modal" role="dialog" aria-modal="true" aria-labelledby="set-rating-modal-title">
+    <button class="import-modal__close" id="close-set-rating-btn" aria-label="Close">&#x2715;</button>
+    <div id="set-rating-modal-body">
+      <h2 id="set-rating-modal-title">Set Rating</h2>
+      <p class="import-modal__desc">
+        Set the rating for these <strong id="set-rating-count">0</strong> images.
+      </p>
+      <form id="set-rating-form"
+            hx-post="{% url 'images-set-rating' %}"
+            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+            hx-target="#set-rating-modal-body"
+            hx-swap="innerHTML">
+        <div id="set-rating-pks-container"></div>
+        <input type="hidden" name="rating" id="set-rating-value" value="0">
+        <div class="set-rating-modal__picker">
+          {% include "images/_rating_picker.html" %}
+        </div>
+        <div class="delete-confirm__actions">
+          <button type="button" class="delete-confirm__no-btn" id="set-rating-cancel-btn">Cancel</button>
+          <button type="submit" class="delete-confirm__yes-btn" id="set-rating-confirm-btn" disabled>Confirm</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var overlay        = document.getElementById('set-rating-overlay');
+    var closeBtn       = document.getElementById('close-set-rating-btn');
+    var _allSucceeded  = false;
+
+    // Snapshot the confirm form once so we can restore it after a submission
+    // replaces the modal body with the result partial.
+    var _confirmHTML = document.getElementById('set-rating-modal-body').innerHTML;
+
+    function handleClose() {
+      overlay.hidden = true;
+      if (_allSucceeded) {
+        _allSucceeded = false;
+        location.reload();
+      }
+    }
+
+    // Wire the star picker: clicking a star (or the clear button) sets the
+    // pending rating, repaints the filled stars, and enables Confirm.
+    function wirePicker(body) {
+      var picker = body.querySelector('#set-rating-picker');
+      var valueInput = body.querySelector('#set-rating-value');
+      var confirmBtn = body.querySelector('#set-rating-confirm-btn');
+      if (!picker) return;
+      picker.addEventListener('click', function (e) {
+        var btn = e.target.closest('[data-rating]');
+        if (!btn) return;
+        var rating = parseInt(btn.getAttribute('data-rating'), 10);
+        valueInput.value = rating;
+        picker.querySelectorAll('.detail-rating-star').forEach(function (star) {
+          var starValue = parseInt(star.getAttribute('data-rating'), 10);
+          star.classList.toggle('detail-rating-star--active', rating >= starValue);
+        });
+        confirmBtn.disabled = false;
+      });
+    }
+
+    function openModal() {
+      _allSucceeded = false;
+
+      // Restore the confirm form (in case a previous submission replaced it).
+      var body = document.getElementById('set-rating-modal-body');
+      body.innerHTML = _confirmHTML;
+      htmx.process(body);
+      wirePicker(body);
+
+      var pks = imageMultiSelect.getSelectedPks();
+      document.getElementById('set-rating-count').textContent = pks.length;
+      var container = document.getElementById('set-rating-pks-container');
+      pks.forEach(function (pk) {
+        var input = document.createElement('input');
+        input.type  = 'hidden';
+        input.name  = 'image_ids';
+        input.value = pk;
+        container.appendChild(input);
+      });
+
+      overlay.hidden = false;
+      document.getElementById('ms-actions-dropdown').hidden = true;
+    }
+
+    document.getElementById('ms-set-rating-btn').addEventListener('click', openModal);
+    closeBtn.addEventListener('click', handleClose);
+
+    // Delegate Cancel button and backdrop clicks (Cancel is inside the modal
+    // body and gets replaced by HTMX after a submission).
+    overlay.addEventListener('click', function (e) {
+      if (e.target === overlay || e.target.closest('#set-rating-cancel-btn')) {
+        handleClose();
+      }
+    });
+
+    document.body.addEventListener('htmx:afterSwap', function (e) {
+      if (e.detail.target.id !== 'set-rating-modal-body') return;
+      var resultEl = e.detail.target.querySelector('[data-all-succeeded]');
+      _allSucceeded = !!(resultEl && resultEl.dataset.allSucceeded === 'true');
+    });
+  }());
+</script>
 
 <script>
   // Multi-select recipe dropdown with search and removable tags.

--- a/src/interfaces/templates/images/partials/set_images_rating_result.html
+++ b/src/interfaces/templates/images/partials/set_images_rating_result.html
@@ -1,0 +1,24 @@
+{% if error %}
+<div class="remove-result remove-result--error" data-all-succeeded="false">
+  <p class="remove-result__message">{{ error }}</p>
+</div>
+
+{% else %}
+<div class="remove-result" data-all-succeeded="{{ all_succeeded|yesno:'true,false' }}">
+  {% if rated_count %}
+  <p class="remove-result__message remove-result__message--success">
+    {{ rated_count }} image{{ rated_count|pluralize }} rated.
+  </p>
+  {% endif %}
+
+  {% if not_found_count %}
+  <p class="remove-result__message remove-result__message--warning">
+    {{ not_found_count }} image{{ not_found_count|pluralize }} could not be found.
+  </p>
+  {% endif %}
+
+  {% if not rated_count and not not_found_count %}
+  <p class="remove-result__message">No images were rated.</p>
+  {% endif %}
+</div>
+{% endif %}

--- a/tests/functional/test_set_images_rating_view.py
+++ b/tests/functional/test_set_images_rating_view.py
@@ -1,0 +1,134 @@
+from unittest.mock import patch
+
+import pytest
+from bs4 import BeautifulSoup
+
+from src.data import models
+from tests.factories import ImageFactory
+
+
+@pytest.mark.django_db
+class TestSetImagesRatingViewMethodGuard:
+    def test_get_returns_405(self, client) -> None:
+        response = client.get("/images/set-rating/")
+        assert response.status_code == 405
+
+
+@pytest.mark.django_db
+class TestSetImagesRatingGalleryPresence:
+    def test_set_rating_action_button_is_in_actions_dropdown(self, client) -> None:
+        response = client.get("/images/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find("button", id="ms-set-rating-btn") is not None
+
+    def test_set_rating_modal_is_in_page(self, client) -> None:
+        response = client.get("/images/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(id="set-rating-overlay") is not None
+
+    def test_form_posts_to_correct_url(self, client) -> None:
+        response = client.get("/images/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        form = soup.find("form", id="set-rating-form")
+        assert form is not None
+        assert form.get("hx-post") == "/images/set-rating/"
+
+    def test_picker_renders_a_star_per_rating_and_a_clear_button(self, client) -> None:
+        response = client.get("/images/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        picker = soup.find(id="set-rating-picker")
+        assert picker is not None
+        assert len(picker.find_all("button", class_="detail-rating-star")) == 5
+        assert picker.find("button", class_="detail-rating-clear") is not None
+
+
+@pytest.mark.django_db
+class TestSetImagesRatingViewSuccess:
+    def test_returns_200(self, client) -> None:
+        image = ImageFactory(rating=0)
+        response = client.post("/images/set-rating/", {"image_ids": [image.pk], "rating": 3})
+        assert response.status_code == 200
+
+    def test_rates_every_selected_image(self, client) -> None:
+        images = [ImageFactory(rating=0) for _ in range(3)]
+        client.post(
+            "/images/set-rating/",
+            {"image_ids": [image.pk for image in images], "rating": 4},
+        )
+        assert list(
+            models.Image.objects.filter(pk__in=[image.pk for image in images]).values_list("rating", flat=True)
+        ) == [4, 4, 4]
+
+    def test_response_shows_rated_count(self, client) -> None:
+        images = [ImageFactory(rating=0) for _ in range(2)]
+        response = client.post(
+            "/images/set-rating/",
+            {"image_ids": [image.pk for image in images], "rating": 2},
+        )
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert "2 image" in soup.get_text().lower()
+
+    def test_marks_all_succeeded_when_all_rated(self, client) -> None:
+        image = ImageFactory(rating=0)
+        response = client.post("/images/set-rating/", {"image_ids": [image.pk], "rating": 3})
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(attrs={"data-all-succeeded": "true"}) is not None
+
+    def test_rating_zero_clears_the_rating(self, client) -> None:
+        image = ImageFactory(rating=4)
+        client.post("/images/set-rating/", {"image_ids": [image.pk], "rating": 0})
+        image.refresh_from_db()
+        assert image.rating == 0
+
+
+@pytest.mark.django_db
+class TestSetImagesRatingViewPartialFailure:
+    def test_missing_id_marks_not_all_succeeded(self, client) -> None:
+        image = ImageFactory(rating=0)
+        response = client.post(
+            "/images/set-rating/",
+            {"image_ids": [image.pk, image.pk + 1000], "rating": 3},
+        )
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(attrs={"data-all-succeeded": "false"}) is not None
+
+    def test_missing_id_shows_not_found_message(self, client) -> None:
+        image = ImageFactory(rating=0)
+        response = client.post(
+            "/images/set-rating/",
+            {"image_ids": [image.pk, image.pk + 1000], "rating": 3},
+        )
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert "could not be found" in soup.get_text().lower()
+
+
+@pytest.mark.django_db
+class TestSetImagesRatingViewBadRequest:
+    def test_non_integer_image_ids_returns_400(self, client) -> None:
+        response = client.post("/images/set-rating/", {"image_ids": ["abc"], "rating": 3})
+        assert response.status_code == 400
+
+    def test_non_integer_rating_returns_400(self, client) -> None:
+        image = ImageFactory(rating=0)
+        response = client.post("/images/set-rating/", {"image_ids": [image.pk], "rating": "x"})
+        assert response.status_code == 400
+
+    def test_out_of_range_rating_shows_error_message(self, client) -> None:
+        image = ImageFactory(rating=0)
+        response = client.post("/images/set-rating/", {"image_ids": [image.pk], "rating": 6})
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(attrs={"data-all-succeeded": "false"}) is not None
+        image.refresh_from_db()
+        assert image.rating == 0
+
+    def test_unexpected_exception_shows_error_message(self, client) -> None:
+        image = ImageFactory(rating=0)
+        with patch(
+            "src.interfaces.images.views.set_images_rating_uc.set_images_rating",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = client.post("/images/set-rating/", {"image_ids": [image.pk], "rating": 3})
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert "unexpected" in soup.get_text().lower()

--- a/tests/integration/application/images/test_set_images_rating.py
+++ b/tests/integration/application/images/test_set_images_rating.py
@@ -1,0 +1,32 @@
+import pytest
+from django.test import override_settings
+
+from src.application.usecases.images import set_images_rating as uc
+from tests.factories import ImageFactory
+
+
+@pytest.mark.django_db
+class TestSetImagesRatingPersistence:
+    @override_settings(IMAGE_MAX_RATING=5)
+    def test_rates_all_selected_images(self) -> None:
+        images = [ImageFactory(rating=0) for _ in range(3)]
+
+        result = uc.set_images_rating(image_ids=[image.pk for image in images], rating=4)
+
+        assert result.rated_count == 3
+        assert result.requested_count == 3
+        assert result.not_found_count == 0
+        for image in images:
+            image.refresh_from_db()
+            assert image.rating == 4
+
+    @override_settings(IMAGE_MAX_RATING=5)
+    def test_reports_not_found_for_missing_ids(self) -> None:
+        image = ImageFactory(rating=0)
+        missing_id = image.pk + 1000
+
+        result = uc.set_images_rating(image_ids=[image.pk, missing_id], rating=2)
+
+        assert result.rated_count == 1
+        assert result.requested_count == 2
+        assert result.not_found_count == 1

--- a/tests/integration/domain/images/test_set_images_rating.py
+++ b/tests/integration/domain/images/test_set_images_rating.py
@@ -1,0 +1,73 @@
+import pytest
+from django.test import override_settings
+
+from src.domain.images import events
+from src.domain.images.operations import set_images_rating
+from tests.factories import ImageFactory
+
+
+@pytest.mark.django_db
+class TestSetImagesRatingPersistence:
+    @override_settings(IMAGE_MAX_RATING=5)
+    def test_updates_every_selected_image(self) -> None:
+        images = [ImageFactory(rating=0) for _ in range(3)]
+
+        updated = set_images_rating(image_ids=[image.pk for image in images], rating=4)
+
+        assert updated == 3
+        for image in images:
+            image.refresh_from_db()
+            assert image.rating == 4
+
+    @override_settings(IMAGE_MAX_RATING=5)
+    def test_leaves_unselected_images_untouched(self) -> None:
+        selected = ImageFactory(rating=0)
+        other = ImageFactory(rating=2)
+
+        set_images_rating(image_ids=[selected.pk], rating=5)
+
+        other.refresh_from_db()
+        assert other.rating == 2
+
+    @override_settings(IMAGE_MAX_RATING=5)
+    def test_ignores_non_existent_ids(self) -> None:
+        image = ImageFactory(rating=0)
+        missing_id = image.pk + 1000
+
+        updated = set_images_rating(image_ids=[image.pk, missing_id], rating=3)
+
+        assert updated == 1
+        image.refresh_from_db()
+        assert image.rating == 3
+
+    @override_settings(IMAGE_MAX_RATING=5)
+    def test_clears_rating_when_set_to_zero(self) -> None:
+        image = ImageFactory(rating=4)
+
+        set_images_rating(image_ids=[image.pk], rating=0)
+
+        image.refresh_from_db()
+        assert image.rating == 0
+
+    @override_settings(IMAGE_MAX_RATING=5)
+    def test_empty_image_ids_is_a_no_op(self, captured_logs) -> None:
+        updated = set_images_rating(image_ids=[], rating=3)
+
+        assert updated == 0
+        rating_events = [e for e in captured_logs if e.get("event_type") == events.IMAGE_RATING_SET]
+        assert rating_events == []
+
+
+@pytest.mark.django_db
+class TestSetImagesRatingEvents:
+    @override_settings(IMAGE_MAX_RATING=5)
+    def test_publishes_one_event_per_updated_image(self, captured_logs) -> None:
+        images = [ImageFactory(rating=0) for _ in range(3)]
+        missing_id = max(image.pk for image in images) + 1000
+
+        set_images_rating(image_ids=[*[image.pk for image in images], missing_id], rating=4)
+
+        rating_events = [e for e in captured_logs if e.get("event_type") == events.IMAGE_RATING_SET]
+        assert {e["image_id"] for e in rating_events} == {image.pk for image in images}
+        assert all(e["rating"] == 4 for e in rating_events)
+        assert missing_id not in {e["image_id"] for e in rating_events}

--- a/tests/unit/application/images/test_set_images_rating.py
+++ b/tests/unit/application/images/test_set_images_rating.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+import pytest
+
+from src.application.usecases.images import set_images_rating as uc
+from src.domain.images.operations import InvalidImageRatingError
+
+_OP = "src.application.usecases.images.set_images_rating.image_operations.set_images_rating"
+
+
+class TestSetImagesRatingResult:
+    def test_result_carries_rated_count_from_operation(self) -> None:
+        with patch(_OP, return_value=2) as mock_op:
+            result = uc.set_images_rating(image_ids=[1, 2, 3], rating=4)
+        mock_op.assert_called_once_with(image_ids=[1, 2, 3], rating=4)
+        assert result.rated_count == 2
+        assert result.requested_count == 3
+        assert result.not_found_count == 1
+
+    def test_not_found_count_is_zero_when_all_rated(self) -> None:
+        with patch(_OP, return_value=3):
+            result = uc.set_images_rating(image_ids=[1, 2, 3], rating=4)
+        assert result.not_found_count == 0
+
+
+class TestSetImagesRatingErrorTranslation:
+    def test_translates_invalid_image_rating_error(self) -> None:
+        with patch(_OP, side_effect=InvalidImageRatingError(rating=6)):
+            with pytest.raises(uc.InvalidRatingError) as exc_info:
+                uc.set_images_rating(image_ids=[1], rating=6)
+        assert exc_info.value.rating == 6

--- a/tests/unit/domain/images/test_set_images_rating.py
+++ b/tests/unit/domain/images/test_set_images_rating.py
@@ -1,0 +1,34 @@
+from unittest import mock
+
+import pytest
+from django.test import override_settings
+
+from src.domain.images import operations
+from src.domain.images.operations import InvalidImageRatingError, set_images_rating
+
+
+class TestSetImagesRatingValidation:
+    def test_raises_when_rating_is_negative(self) -> None:
+        with pytest.raises(InvalidImageRatingError) as exc_info:
+            set_images_rating(image_ids=[1, 2], rating=-1)
+        assert exc_info.value.rating == -1
+
+    @override_settings(IMAGE_MAX_RATING=5)
+    def test_raises_when_rating_exceeds_max(self) -> None:
+        with pytest.raises(InvalidImageRatingError) as exc_info:
+            set_images_rating(image_ids=[1, 2], rating=6)
+        assert exc_info.value.rating == 6
+
+    @override_settings(IMAGE_MAX_RATING=5)
+    def test_does_not_touch_db_when_rating_is_invalid(self) -> None:
+        with mock.patch.object(operations.models.Image, "objects") as objects:
+            with pytest.raises(InvalidImageRatingError):
+                set_images_rating(image_ids=[1, 2], rating=6)
+        objects.filter.assert_not_called()
+
+    @override_settings(IMAGE_MAX_RATING=5)
+    def test_does_not_publish_events_when_rating_is_invalid(self) -> None:
+        with mock.patch.object(operations.events, "publish_event") as publish_event:
+            with pytest.raises(InvalidImageRatingError):
+                set_images_rating(image_ids=[1, 2], rating=6)
+        publish_event.assert_not_called()


### PR DESCRIPTION
**What**

Adds a **Set rating** batch action to the image gallery's multi-select toolbar.
Select images, open _Actions → Set rating_, pick a rating (or ✕ to
clear), and confirm to apply it to all of them at once. Mirrors the existing
bulk-delete flow.
