### PR TITLE
Stop tests reading the developer's personal env file

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = src.config.settings
 pythonpath = .
+# Loaded during preparse, before pytest-django imports the settings module. See the plugin.
+addopts = -p tests.pytest_plugin_settings_isolation

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -3,11 +3,14 @@ from envparse import Env
 from kombu import Queue
 from pathlib import Path
 
+import os
 import structlog
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
-load_dotenv(BASE_DIR / "src/config/env")
+# Defaults to the developer's personal, gitignored config. Override to read a different file,
+# or os.devnull to ignore it entirely and run purely on the defaults declared below.
+load_dotenv(os.environ.get("FILMCASE_ENV_FILE", BASE_DIR / "src/config/env"))
 
 env = Env()
 

--- a/tests/pytest_plugin_settings_isolation.py
+++ b/tests/pytest_plugin_settings_isolation.py
@@ -1,0 +1,23 @@
+"""
+Keep the test suite off the developer's personal src/config/env file.
+
+src/config/env is gitignored, so CI never has one and always runs on the defaults declared
+in settings.py. If the suite read it too, a locally tuned setting would silently change what
+the tests assert against, producing failures that reproduce on one machine but not on CI.
+
+Pointing FILMCASE_ENV_FILE at os.devnull makes settings.py read an empty file, so every
+setting falls back to its declared default.
+
+This has to be a `-p` plugin rather than a conftest.py hook. pytest-django sets Django up in
+`pytest_load_initial_conftests`, the same hook that loads the root conftest, and it wins that
+race — so by the time conftest.py runs, settings.py has already been imported and the env file
+already read. Plugins named with `-p` in pytest.ini are imported during preparse, before any of
+that, which is early enough.
+
+Real environment variables still take precedence, because load_dotenv does not override them.
+A contributor whose database differs from the defaults can still use e.g. `DB_PORT=5433 pytest`.
+"""
+
+import os
+
+os.environ["FILMCASE_ENV_FILE"] = os.devnull

--- a/tests/unit/test_settings_isolation.py
+++ b/tests/unit/test_settings_isolation.py
@@ -1,0 +1,25 @@
+"""
+Guard the test suite against reading the developer's personal src/config/env.
+
+That file is gitignored, so CI never has one and always runs on the defaults declared
+in settings.py. If the suite reads it too, a locally tuned setting silently changes what
+the tests assert against, producing failures that reproduce on one machine and not on CI.
+"""
+
+import os
+
+from django.conf import settings
+
+
+class TestPersonalEnvIsolation:
+    def test_env_file_is_redirected_before_settings_are_imported(self) -> None:
+        # settings.py reads whatever FILMCASE_ENV_FILE points at. The -p plugin in pytest.ini
+        # aims it at os.devnull, and must be imported before pytest-django sets Django up;
+        # a conftest.py hook runs too late. If this is unset the plugin stopped loading.
+        assert os.environ.get("FILMCASE_ENV_FILE") == os.devnull
+
+    def test_settings_match_the_declared_defaults(self) -> None:
+        # A representative setting that a developer is likely to tune locally. It must hold
+        # the settings.py default, not whatever src/config/env happens to say. This is the
+        # assertion that actually fails if the flag is set too late to matter.
+        assert settings.IMAGE_MAX_RATING == 5


### PR DESCRIPTION
settings.py loaded src/config/env unconditionally, and pytest.ini points at that same settings module, so the suite ran on whatever the local machine happened to be configured for. The file is gitignored, so CI has none and always runs on the declared defaults. Any locally tuned setting therefore changed what the tests asserted against, failing on one machine while passing in CI. A local IMAGE_MAX_RATING of 2 was breaking four set_images_rating tests this way.

load_dotenv now reads whatever FILMCASE_ENV_FILE points at, defaulting to the personal file so runtime behaviour is unchanged. A pytest plugin aims it at os.devnull, an empty file by definition, so every setting falls back to its default. Real environment variables still win over the file, so a contributor whose database differs from the defaults can still use DB_PORT=5433 pytest.

This has to be a -p plugin rather than a conftest.py hook. pytest-django sets Django up in pytest_load_initial_conftests, the same hook that loads the root conftest, and it wins that race, so by then the settings module is already imported and the env file already read. Plugins named with -p are imported during preparse, which is early enough.