### PR TITLE
Add docker installation mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Keep the build context small, and keep local state out of the image. src/config/env
+# matters most: it is the developer's personal, gitignored configuration, and baking it in
+# would silently override every environment variable the container is given.
+.git/
+.venv/
+venv/
+
+src/config/env
+db.sqlite3
+db.sqlite3-journal
+
+logs/
+thumbnail_cache/
+recipe_cards/
+investigation/
+
+# The developer's own photo collection, gitignored and referenced by no application code.
+# Left in the context it dominates the image: 3.8 GB of a 4.4 GB build here.
+assets/
+
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.import_linter_cache/
+.coverage
+htmlcov/
+
+.claude/
+.github/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,32 @@
+# Reference for the values the container reads. `./setup.sh docker` writes a real .env for
+# you, with defaults detected from the machine, so copy this only if you would rather
+# configure it by hand:
+#
+#   cp .env.example .env
+
+# The address you will type in the browser. It goes into the certificate's subjectAltName
+# and into CSRF_TRUSTED_ORIGINS, so it has to match exactly. Use the server's LAN address,
+# or localhost when running on your own machine.
+#
+# Reaching the app on any other address than this one will fail CSRF checks on POST.
+FILMCASE_HOST=localhost
+FILMCASE_HTTPS_PORT=8443
+
+# Ownership for the mounted directories and the app process. These should be the user that
+# owns your photo directories: run `id <your-user>` on the host to find them.
+PUID=1000
+PGID=1000
+
+# Process counts. Each Celery process loads Django and Pillow, so on a small server keep
+# this near the core count rather than above it.
+FILMCASE_WEB_WORKERS=2
+FILMCASE_WORKER_CONCURRENCY=4
+
+# Django signing key. Generate one with:
+#
+#   openssl rand -base64 48
+FILMCASE_SECRET_KEY=change-me
+
+# PostgreSQL password. Only reachable from inside the compose network. Changing it after
+# the first start locks the app out of the existing database volume.
+FILMCASE_DB_PASSWORD=change-me

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ db.sqlite3
 db.sqlite3-journal
 src/config/env
 
+# Docker Compose reads this for the signing key, database password and host address.
+# .env.example is the tracked template.
+.env
+
 # Logs
 logs/
 
@@ -53,3 +57,6 @@ recipe_cards/
 
 # Investigation notes
 investigation/
+
+# Local compose overrides (photo directory paths). The .example file is tracked.
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM python:3.12-slim
+
+# exiftool is not optional: the import pipeline shells out to it for every recipe field
+# (src/domain/images/queries.py), so without it the container cannot do the one thing it
+# exists for. libusb only matters when a camera is passed through to the container, which
+# a NAS install never does; it is kept because it costs ~100KB and keeps the desktop
+# passthrough deployment working. openssl generates the self-signed certificate on first
+# run, and gosu drops privileges once the entrypoint has fixed ownership on the volumes.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libimage-exiftool-perl \
+        libusb-1.0-0 \
+        openssl \
+        gosu \
+    && rm -rf /var/lib/apt/lists/*
+
+# settings.py reads src/config/env unless told otherwise, and that file is the developer's
+# personal configuration. Pointing at os.devnull is the documented way to ignore it and run
+# purely on environment variables, which is what compose supplies.
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    FILMCASE_ENV_FILE=/dev/null \
+    DJANGO_SETTINGS_MODULE=src.config.settings
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN chmod +x /app/docker/entrypoint.sh
+
+EXPOSE 8443
+
+ENTRYPOINT ["/app/docker/entrypoint.sh"]
+CMD ["web"]

--- a/Makefile
+++ b/Makefile
@@ -10,17 +10,20 @@ ENV_FILE := src/config/env
 # (e.g. `start` calling `run`); they name the same directory and only add noise.
 MAKEFLAGS += --no-print-directory
 
-.PHONY: setup-lite setup-full env env-lite update start run worker test help
+.PHONY: setup-lite setup-full setup-docker docker-up docker-down docker-logs docker-update env env-lite update start run worker test help
 
 ##
 ## Installation modes:
 ##
-##   setup-lite  — SQLite, sequential processing. No OS services required.
-##                 Simpler setup, slower import. Best for personal use.
+##   setup-lite   — SQLite, sequential processing. No OS services required.
+##                  Simpler setup, slower import. Best for personal use.
 ##
-##   setup-full  — PostgreSQL + Celery. Run ./setup.sh first to install OS
-##                 dependencies (PostgreSQL, RabbitMQ). Parallel processing.
-##                 Best for development and large collections.
+##   setup-full   — PostgreSQL + Celery. Run ./setup.sh first to install OS
+##                  dependencies (PostgreSQL, RabbitMQ). Parallel processing.
+##                  Best for development and large collections.
+##
+##   setup-docker — Everything in containers, served over HTTPS. Installs
+##                  nothing on the host. Best for a NAS or an always-on box.
 ##
 
 ## setup-lite  — install lite stack (SQLite, no broker/worker required)
@@ -36,6 +39,32 @@ setup-full: $(VENV)/.deps-installed env
 	@$(PYTHON) manage.py migrate
 	@echo ""
 	@echo "Done. Start the Celery worker with 'make worker', then run 'make start' to sync your library and start the server."
+
+## setup-docker  — configure the containerised install (writes .env and the compose override)
+setup-docker:
+	@./setup.sh docker
+
+## docker-up     — build and start the container stack
+docker-up:
+	@docker compose up -d --build
+
+## docker-down   — stop the container stack, keeping all volumes
+docker-down:
+	@docker compose down
+
+## docker-logs   — follow the web server log
+docker-logs:
+	@docker compose logs -f web
+
+## docker-update — pull latest changes, rebuild the image and restart
+docker-update:
+	@echo "[update] Pulling latest changes..."
+	@git pull origin main
+	@echo "[update] Rebuilding and restarting..."
+	@docker compose up -d --build
+	@echo ""
+	@echo "Done. The rebuild installed any new dependencies, and migrations were applied"
+	@echo "as the web container started."
 
 ## env         — generate src/config/env from settings defaults (skips if already exists)
 env:
@@ -89,6 +118,11 @@ $(VENV)/bin/activate:
 
 ## update      — pull latest changes, install new dependencies, and run migrations
 update:
+	@if [ ! -x "$(PYTHON)" ]; then \
+		echo "[update] No virtualenv found at $(VENV)/."; \
+		echo "[update] A Docker install has no virtualenv: use 'make docker-update' instead."; \
+		exit 1; \
+	fi
 	@echo "[update] Pulling latest changes..."
 	@git pull origin main
 	@echo "[update] Installing dependencies..."

--- a/README.md
+++ b/README.md
@@ -29,15 +29,17 @@ Read more about it in our [documentation index](docs/index.md).
 
 ## Installation
 
-Two installation modes are available depending on your needs:
+Three installation modes are available depending on your needs:
 
-|                            | Lite (user-only)              | Full (developer)               |
-| -------------------------- | ----------------------------- | ------------------------------ |
-| **Database**               | SQLite (file, no server)      | PostgreSQL                     |
-| **Broker / worker**        | None                          | RabbitMQ + Celery              |
-| **Image processing**       | Sequential (one at a time)    | Parallel (N workers)           |
-| **OS services to install** | None                          | PostgreSQL, RabbitMQ           |
-| **Best for**               | Personal use, small libraries | Development, large collections |
+|                            | Lite (user-only)              | Full (developer)               | Docker (any server)             |
+| -------------------------- | ----------------------------- | ------------------------------ | ------------------------------- |
+| **Database**               | SQLite (file, no server)      | PostgreSQL                     | PostgreSQL (container)          |
+| **Broker / worker**        | None                          | RabbitMQ + Celery              | RabbitMQ + Celery (containers)  |
+| **Image processing**       | Sequential (one at a time)    | Parallel (N workers)           | Parallel (N workers)            |
+| **OS services to install** | None                          | PostgreSQL, RabbitMQ           | Docker only                     |
+| **Served over**            | HTTP on localhost             | HTTP on localhost              | HTTPS, self-signed certificate  |
+| **Push recipes to camera** | Yes                           | Yes                            | Only with USB passthrough       |
+| **Best for**               | Personal use, small libraries | Development, large collections | Always-on servers, remote access |
 
 ### Lite install (recommended for personal use)
 
@@ -92,13 +94,56 @@ worker before enqueuing tasks and skips the sync if none is found.
 
 ---
 
+### Docker install (any always-on server)
+
+Runs the full stack in containers, with nothing to install on the host but Docker itself.
+
+```bash
+./setup.sh docker
+```
+
+That asks for the address you will browse to, the photo directories to import, and how many
+processes to run, filling in your LAN address and user id as defaults. It generates the
+signing key and database password itself, writes `.env` and `docker-compose.override.yml`,
+and offers to build and start. Nothing is installed on the host and no file needs editing.
+
+Re-run it whenever you want to change an answer: existing values come back as the defaults,
+and the generated secrets are preserved.
+
+Then open `https://<FILMCASE_HOST>:8443/` and accept the certificate warning once.
+
+Two things behave differently from a native install:
+
+- **It is served over HTTPS with a self-signed certificate**, so every browser shows a
+  warning the first time. That is the cost of not owning a domain, and it buys a secure
+  context, which browsers require before exposing USB and other capabilities.
+- **Pushing recipes to a camera does not work on a NAS yet**, because the camera is
+  plugged into your desk rather than into the server. On a desktop you can pass the USB
+  bus through to the container today. Moving the transport into the browser over WebUSB
+  would lift the restriction entirely, and that work is under way: the diagnostics page at
+  `/camera/diagnostics/` reports whether your browser can reach the camera.
+
+Full details, including how to swap in a trusted certificate, are in
+[docs/docker.md](docs/docker.md).
+
+> **Filmcase has no authentication.** Anyone who can reach the port has full access,
+> including the Library page that browses the filesystem. Do not expose it to the internet.
+
+---
+
 ## Updating
 
 To pull the latest changes, install any new dependencies, and apply pending migrations in one step:
 
 ```bash
-make update
+make update          # lite and full installs
+make docker-update   # Docker install
 ```
+
+The Docker variant rebuilds the image and restarts instead of touching a virtualenv. It
+builds before it replaces anything, so a failed build leaves the running stack untouched.
+Avoid running it while a library sync is in progress: see
+[docs/docker.md](docs/docker.md#updating).
 
 ---
 

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,32 @@
+# Reference for the photo directory mounts. `./setup.sh docker` writes a real override for
+# you from the directories you name, so copy this only if you would rather configure it by
+# hand:
+#
+#   cp docker-compose.override.yml.example docker-compose.override.yml
+#
+# Compose reads docker-compose.override.yml automatically on top of docker-compose.yml, and
+# it is gitignored, so your paths stay out of the repository.
+#
+# Mount each directory at the same path it has on the host. Filmcase stores absolute paths
+# in the database, so mounting /srv/photos at /srv/photos means the path you type on the
+# Library page is the path the container sees, and stored folders survive a move between a
+# Docker and a native install.
+#
+# Read-only is deliberate: Filmcase never writes to your originals.
+#
+# Both services need the same mounts. The worker does the importing, so a directory the web
+# service can see but the worker cannot would fail at sync time rather than when adding it.
+#
+# Named volumes from docker-compose.yml do not need repeating here: compose merges volumes
+# by target path rather than replacing the list.
+
+services:
+  web:
+    volumes:
+      - /srv/photos:/srv/photos:ro
+      # - /home/youruser/Pictures:/home/youruser/Pictures:ro
+
+  celery_worker:
+    volumes:
+      - /srv/photos:/srv/photos:ro
+      # - /home/youruser/Pictures:/home/youruser/Pictures:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,101 @@
+# Filmcase, full stack: PostgreSQL and RabbitMQ alongside the web server and a Celery
+# worker. Full mode rather than lite because compose supplies the two services that make a
+# manual full install awkward, and because the sequential SQLite path still aborts a whole
+# sync run on a single unreadable recipe.
+#
+# Copy .env.example to .env and edit it before the first `docker compose up -d`.
+
+x-filmcase-env: &filmcase-env
+  FILMCASE_ENV_FILE: /dev/null
+  DJANGO_SETTINGS_MODULE: src.config.settings
+  DEBUG: "False"
+  SECRET_KEY: ${FILMCASE_SECRET_KEY:-django-insecure-filmcase-dev-key}
+  FILMCASE_HOST: ${FILMCASE_HOST:-localhost}
+  FILMCASE_HTTPS_PORT: ${FILMCASE_HTTPS_PORT:-8443}
+  PUID: ${PUID:-1000}
+  PGID: ${PGID:-1000}
+  DB_ENGINE: django.db.backends.postgresql
+  DB_NAME: fujifilm_recipes
+  DB_USER: fujifilm_recipes
+  DB_PASSWORD: ${FILMCASE_DB_PASSWORD:-fujifilm_recipes}
+  DB_HOST: db
+  DB_PORT: "5432"
+  CELERY_BROKER_URL: amqp://guest:guest@rabbitmq:5672//
+  USE_ASYNC_TASKS: "True"
+
+x-filmcase-volumes: &filmcase-volumes
+  - certs:/certs
+  - thumbnail_cache:/app/thumbnail_cache
+  - recipe_cards:/app/recipe_cards
+  - logs:/app/logs
+  # Photo directories are deliberately absent. Compose overrides can only add mounts, never
+  # remove one, so a placeholder path here would be mounted on every install and Docker
+  # would create it, root-owned and empty, on hosts that do not have it.
+  #
+  # Copy docker-compose.override.yml.example to docker-compose.override.yml and list your
+  # own directories there. Compose reads that file automatically.
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: fujifilm_recipes
+      POSTGRES_USER: fujifilm_recipes
+      POSTGRES_PASSWORD: ${FILMCASE_DB_PASSWORD:-fujifilm_recipes}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U fujifilm_recipes"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  rabbitmq:
+    image: rabbitmq:4-alpine
+    restart: unless-stopped
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  web:
+    build: .
+    image: filmcase:latest
+    restart: unless-stopped
+    command: ["web"]
+    environment: *filmcase-env
+    volumes: *filmcase-volumes
+    ports:
+      - "${FILMCASE_HTTPS_PORT:-8443}:${FILMCASE_HTTPS_PORT:-8443}"
+    depends_on:
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+
+  celery_worker:
+    build: .
+    image: filmcase:latest
+    restart: unless-stopped
+    command: ["worker"]
+    environment: *filmcase-env
+    volumes: *filmcase-volumes
+    depends_on:
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      web:
+        condition: service_started
+
+volumes:
+  postgres_data:
+  rabbitmq_data:
+  certs:
+  thumbnail_cache:
+  recipe_cards:
+  logs:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Container entrypoint. Prepares the writable volumes and the TLS certificate, then hands
+# off to either the web server or a Celery worker.
+#
+# Usage (as the container command):
+#   web      start gunicorn over HTTPS, after applying migrations
+#   worker   start a Celery worker
+#   <other>  run the given command verbatim, as the unprivileged user
+#
+set -euo pipefail
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+FILMCASE_HOST="${FILMCASE_HOST:-localhost}"
+FILMCASE_HTTPS_PORT="${FILMCASE_HTTPS_PORT:-8443}"
+
+CERT_DIR="${FILMCASE_CERT_DIR:-/certs}"
+CERT_FILE="$CERT_DIR/filmcase.crt"
+KEY_FILE="$CERT_DIR/filmcase.key"
+
+log() { echo "[entrypoint] $*"; }
+
+# Docker creates named volumes owned by root, so ownership is fixed here while still root,
+# before dropping to the account that actually runs the app. Only the directories are
+# chowned, never their contents: a populated thumbnail cache can hold tens of thousands of
+# files and a recursive chown on every boot would cost minutes for no benefit.
+prepare_directories() {
+    for dir in "$CERT_DIR" /app/thumbnail_cache /app/recipe_cards /app/logs; do
+        mkdir -p "$dir"
+        chown "$PUID:$PGID" "$dir"
+    done
+}
+
+# A self-signed certificate is enough to reach a secure context, which is what WebUSB and
+# the other powerful browser APIs actually test for: the check is on the origin's scheme,
+# not on whether the chain is trusted. Browsers still show a full-page interstitial that
+# has to be accepted once per browser, which is the documented cost of not owning a domain.
+#
+# The address users type must appear in the subjectAltName. Modern browsers ignore CN
+# entirely, and an IP needs an IP: SAN rather than a DNS: one.
+generate_certificate() {
+    if [ -f "$CERT_FILE" ] && [ -f "$KEY_FILE" ]; then
+        log "Reusing the certificate in $CERT_DIR"
+        return
+    fi
+
+    local san
+    if echo "$FILMCASE_HOST" | grep -Eq '^[0-9]{1,3}(\.[0-9]{1,3}){3}$'; then
+        san="IP:$FILMCASE_HOST"
+    else
+        san="DNS:$FILMCASE_HOST"
+    fi
+
+    log "Generating a self-signed certificate for $FILMCASE_HOST ($san)"
+    openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+        -keyout "$KEY_FILE" \
+        -out "$CERT_FILE" \
+        -subj "/CN=$FILMCASE_HOST" \
+        -addext "subjectAltName=$san" \
+        >/dev/null 2>&1
+
+    chown "$PUID:$PGID" "$CERT_FILE" "$KEY_FILE"
+    chmod 640 "$KEY_FILE"
+    chmod 644 "$CERT_FILE"
+}
+
+# Compose may pin the container to a specific account with `user:`, in which case there are
+# no privileges to drop and nothing to chown. Run the command directly in that case.
+run_as_app_user() {
+    if [ "$(id -u)" = "0" ]; then
+        exec gosu "$PUID:$PGID" "$@"
+    fi
+    exec "$@"
+}
+
+if [ "$(id -u)" = "0" ]; then
+    prepare_directories
+    generate_certificate
+fi
+
+case "${1:-web}" in
+    web)
+        log "Applying migrations"
+        if [ "$(id -u)" = "0" ]; then
+            gosu "$PUID:$PGID" python manage.py migrate --noinput
+        else
+            python manage.py migrate --noinput
+        fi
+
+        log "Starting gunicorn on https://$FILMCASE_HOST:$FILMCASE_HTTPS_PORT/"
+        run_as_app_user gunicorn src.config.wsgi:application \
+            --bind "0.0.0.0:$FILMCASE_HTTPS_PORT" \
+            --certfile "$CERT_FILE" \
+            --keyfile "$KEY_FILE" \
+            --workers "${FILMCASE_WEB_WORKERS:-3}" \
+            --timeout "${FILMCASE_WEB_TIMEOUT:-120}" \
+            --access-logfile -
+        ;;
+    worker)
+        log "Starting Celery worker"
+        run_as_app_user celery -A src.config worker \
+            --loglevel=info \
+            --concurrency="${FILMCASE_WORKER_CONCURRENCY:-8}"
+        ;;
+    *)
+        run_as_app_user "$@"
+        ;;
+esac

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,239 @@
+# Running Filmcase in Docker
+
+Runs the **full** stack: PostgreSQL, RabbitMQ, the web server and a Celery worker. Full
+mode rather than lite, because compose supplies the two services that make a manual full
+install awkward, so the parallel import path costs nothing extra to set up here.
+
+The web server is served over **HTTPS** with a self-signed certificate generated on first
+run. That is not decoration: browsers only expose USB, and several other capabilities, to a
+secure context, and plain HTTP to a LAN address never qualifies. See
+[HTTPS and the certificate warning](#https-and-the-certificate-warning).
+
+---
+
+## Quick start
+
+```bash
+./setup.sh docker
+```
+
+It checks that Docker and Compose v2 are present, asks a handful of questions with sensible
+defaults detected from the machine, writes `.env` and `docker-compose.override.yml`, and
+offers to build and start. Then open `https://<FILMCASE_HOST>:8443/` and accept the
+certificate warning once.
+
+Unlike the other two modes the script installs nothing on the host, so it runs anywhere
+with bash and Docker, not only on macOS and Ubuntu.
+
+Re-running it is safe and is the intended way to change an answer: existing values become
+the prompt defaults, configured photo directories are kept, and the generated signing key
+and database password are preserved rather than regenerated. Regenerating the database
+password would lock the app out of an existing PostgreSQL volume.
+
+Both files are gitignored. `.env.example` and `docker-compose.override.yml.example` are
+tracked as a reference if you would rather write them by hand.
+
+---
+
+## Configuration
+
+Compose reads `.env` from the same directory. `.env.example` is the template.
+
+| Variable                | Default              | Purpose                                                        |
+| ----------------------- | -------------------- | -------------------------------------------------------------- |
+| `FILMCASE_HOST`         | `localhost`          | Address you type in the browser. Goes into the certificate SAN and the trusted CSRF origin. |
+| `FILMCASE_HTTPS_PORT`   | `8443`               | Published port.                                                |
+| `PUID` / `PGID`         | `1000` / `1000`      | Account that owns the volumes and runs the app.                |
+| `FILMCASE_WEB_WORKERS`  | `3`                  | gunicorn processes.                                            |
+| `FILMCASE_WORKER_CONCURRENCY` | `8`            | Celery processes. Each loads Django and Pillow, so keep it near the core count on a server that is running other things. |
+| `FILMCASE_SECRET_KEY`   | insecure dev default | Django signing key. Generate one before exposing the app.      |
+| `FILMCASE_DB_PASSWORD`  | `fujifilm_recipes`   | PostgreSQL password, reachable only inside the compose network. Changing it after first start locks the app out of the existing volume. |
+
+`FILMCASE_HOST` must match what you actually type. It is written into the certificate as a
+`subjectAltName` and reused to derive `CSRF_TRUSTED_ORIGINS`, so reaching the app on any
+other address gives a certificate mismatch and fails every POST. Set
+`CSRF_TRUSTED_ORIGINS` explicitly if the install needs to answer on several names.
+
+---
+
+## Mounting your photo directories
+
+Photo directories live in `docker-compose.override.yml`, which compose reads automatically
+and which is gitignored so your paths stay out of the repository. Copy the tracked
+`.example` file and edit it:
+
+```yaml
+services:
+  web:
+    volumes:
+      - /srv/photos:/srv/photos:ro
+  celery_worker:
+    volumes:
+      - /srv/photos:/srv/photos:ro
+```
+
+Mount each directory at **the same path it has on the host**. Filmcase stores the absolute
+path of each library folder in the database, so mounting at the identical path means the
+value you type on the Library page is the path the container sees, stored paths stay valid,
+and moving between a Docker and a native install does not strand your library. Read-only is
+deliberate: Filmcase never writes to the originals.
+
+Both services need the same mounts. The worker does the importing, so a directory the web
+service can see but the worker cannot would fail at sync time rather than when you add it.
+
+Named volumes do not need repeating in the override: compose merges volumes by target path
+rather than replacing the list. That merge is also why `docker-compose.yml` lists no photo
+directory of its own, since an override can add a mount but never remove one.
+
+---
+
+## HTTPS and the certificate warning
+
+On first start the entrypoint generates a self-signed certificate for `FILMCASE_HOST` and
+hands it to gunicorn. Your browser will show a full-page warning the first time, along the
+lines of "Your connection is not private". Accept it once per browser and the app works
+normally afterwards.
+
+**Why not plain HTTP?** Browsers gate powerful APIs behind a *secure context*, and the
+check is on the origin's scheme, not on whether the certificate chains to a trusted
+authority. So:
+
+| Origin                        | Secure context | Powerful APIs |
+| ----------------------------- | -------------- | ------------- |
+| `http://localhost:8443`       | yes            | available     |
+| `https://192.168.1.10:8443` with a self-signed certificate | yes, after accepting the warning | available |
+| `http://192.168.1.10:8443`    | no             | unavailable   |
+
+A self-signed certificate is therefore enough. Private IP addresses are never treated as
+trustworthy on their own, and that has not changed despite a
+[long-standing proposal](https://github.com/w3c/webappsec-secure-contexts/issues/60) to make
+it so.
+
+**To get rid of the warning entirely** you need a certificate that chains to something the
+browser already trusts, which means a real hostname:
+
+- Put a reverse proxy in front of the container and give it a certificate for a real
+  hostname. Most NAS platforms include a reverse proxy and a free dynamic-DNS hostname with
+  a managed certificate, which needs nothing installed on any client.
+- Or serve it through a mesh VPN that issues real certificates for its own hostnames.
+
+Both are optional. The self-signed default works without owning a domain or installing
+anything on the machines you browse from.
+
+**Regenerating the certificate**, after changing `FILMCASE_HOST`:
+
+```bash
+docker compose down
+docker volume rm filmcase_certs
+docker compose up -d
+```
+
+---
+
+## Camera access
+
+Pushing a recipe to a camera reads the camera over USB from **the machine running the
+server**. In a container that has consequences worth being explicit about:
+
+- **On a remote server: pushing recipes does not work yet.** The camera is on your desk and
+  the server is elsewhere, and no amount of configuration bridges that. Moving the transport
+  into the browser over WebUSB would remove the restriction entirely, since the browser runs
+  on the machine the camera is plugged into. That work is under way.
+- **On a desktop: it can work**, if you pass the USB bus through to the container. Add to
+  the `web` service:
+
+  ```yaml
+  devices:
+    - /dev/bus/usb:/dev/bus/usb
+  ```
+
+  and see [camera_usb_access.md](camera_usb_access.md) for the udev rules the host still
+  needs.
+
+The image ships `libusb` for that second case. It is unused on a remote server.
+
+### Checking what your browser can do
+
+`https://<FILMCASE_HOST>:8443/camera/diagnostics/` reports whether the page is a secure
+context, whether the browser exposes WebUSB, and whether it can select, open and claim the
+camera. Useful for confirming the certificate is doing its job, and for testing whether a
+browser-side transport is viable on your setup.
+
+WebUSB is Chromium-only. Firefox and Safari do not implement it.
+
+---
+
+## Security
+
+**Filmcase has no authentication.** Every page, including the Library page that browses the
+filesystem, is available to anyone who can reach the port. TLS encrypts the connection, it
+does not restrict who connects.
+
+That is fine on a laptop bound to localhost. Publishing it on a network where you do not
+trust everyone is a different proposition, and you should put it behind your NAS's reverse
+proxy with authentication, or on a private network such as a VPN, rather than exposing
+the port directly. Never forward this port from the internet.
+
+---
+
+## Running on a NAS or headless server
+
+- `PUID` / `PGID` must be the account that owns your photo directories, not necessarily
+  `1000`. Appliance operating systems often assign different ids to the first user account.
+  Run `id <your-user>` on the host to find them; `./setup.sh docker` fills in the id of
+  whoever runs it.
+- If the machine already runs a reverse proxy, point it at the container and let it present
+  a trusted certificate, keeping the self-signed one for the hop between them.
+- Pick a `FILMCASE_HTTPS_PORT` that nothing else is using. `./setup.sh docker` warns if the
+  port it is about to publish is already listening.
+- Keep the process counts modest. A server that is already running other services will not
+  enjoy a Celery worker per core, and each worker process loads Django and Pillow.
+
+---
+
+## Updating
+
+```bash
+make docker-update
+```
+
+That pulls, rebuilds and restarts. `make update` is for the other two install modes and
+will refuse to run here: it drives a virtualenv that a Docker install does not have.
+
+The equivalent by hand is two commands:
+
+```bash
+git pull origin main
+docker compose up -d --build
+```
+
+Neither step needs anything installed on the host. The rebuild picks up new dependencies
+from `requirements.txt`, and the entrypoint applies migrations as the web container starts.
+
+**What happens to the running app.** The image is built first, while the current containers
+keep serving. Only once the build succeeds does compose replace them, so a failed build
+costs nothing and leaves the running stack exactly as it was. Downtime is the few seconds of
+recreating the containers, plus however long any new migration takes.
+
+Only `web` and `celery_worker` are replaced, since they are the two built from this
+repository. `db` and `rabbitmq` are untouched, and no data volume is affected by an update.
+
+**Do not update while a library sync is running.** Celery acknowledges a task when the
+worker receives it rather than when it finishes, so replacing the worker mid-import drops
+whatever it was holding, which can be several hundred images once prefetching is taken into
+account. Nothing is corrupted or deleted: those files simply were never imported, so the
+next sync finds them missing from the catalog and picks them up. Run one afterwards if you
+are unsure. The Library page shows whether a sync is active.
+
+---
+
+## Operating it
+
+```bash
+docker compose logs -f web          # follow the web server
+docker compose exec web python manage.py sync_library
+docker compose down                 # stop, keeping all volumes
+docker compose up -d --build        # rebuild after pulling changes
+```
+
+Migrations run automatically on every start of the `web` service.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@
 
 - [Web Interface](web_interface.md) — library folder management, image gallery, image detail, recipe explorer, recipe detail, and recipe graphs
 - [Management Commands](management_commands.md) — syncing the library, importing images, bulk rating, thumbnails, camera inspection, recipe comparison
+- [Running in Docker](docker.md) — the containerised full stack, HTTPS with a self-signed certificate, mounting photo directories, and what camera access can and cannot do in a container
 
 ## Reference
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==6.0.3
+gunicorn==23.0.0
 celery==5.6.2
 psycopg2-binary==2.9.11
 pillow==12.1.1

--- a/setup.sh
+++ b/setup.sh
@@ -5,9 +5,14 @@
 #   ./setup.sh          # full stack (PostgreSQL + RabbitMQ + Celery)
 #   ./setup.sh lite     # lite install (SQLite, no broker/worker)
 #   ./setup.sh full     # same as default
+#   ./setup.sh docker   # containerised install: configure .env and the compose override
 #
-# Idempotent: skips anything already installed or running.
-# Supports macOS (Homebrew) and Ubuntu/Debian (apt).
+# Idempotent: skips anything already installed or running. Docker mode reads any existing
+# configuration back as the defaults, so re-running it to change one answer is safe.
+#
+# Supports macOS (Homebrew) and Ubuntu/Debian (apt). Docker mode additionally runs anywhere
+# with bash and Docker, because the container carries every dependency the other two
+# modes install on the host.
 set -euo pipefail
 
 GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
@@ -17,8 +22,8 @@ die()  { echo -e "${RED}[error]${NC} $*" >&2; exit 1; }
 
 # ── Mode ───────────────────────────────────────────────────────────────────────
 MODE="${1:-full}"
-if [[ "$MODE" != "lite" && "$MODE" != "full" ]]; then
-    die "Unknown mode '$MODE'. Use 'lite' or 'full'."
+if [[ "$MODE" != "lite" && "$MODE" != "full" && "$MODE" != "docker" ]]; then
+    die "Unknown mode '$MODE'. Use 'lite', 'full' or 'docker'."
 fi
 
 if [[ "$MODE" == "lite" ]]; then
@@ -27,6 +32,11 @@ if [[ "$MODE" == "lite" ]]; then
     echo "  Installing: Python, libusb, exiftool."
     echo "  Skipping:   PostgreSQL, RabbitMQ."
     echo "  Run 'make setup-lite' after this script completes."
+elif [[ "$MODE" == "docker" ]]; then
+    echo ""
+    echo "  Docker install — PostgreSQL + RabbitMQ + Celery, all in containers."
+    echo "  Installing: nothing on this host; the image carries every dependency."
+    echo "  Configuring: .env and docker-compose.override.yml, from your answers below."
 else
     echo ""
     echo "  Full install — PostgreSQL + Celery, parallel processing."
@@ -36,12 +46,19 @@ fi
 echo ""
 
 # ── Detect OS ──────────────────────────────────────────────────────────────────
+# Docker mode tolerates an unrecognised OS: it installs nothing on the host, so bash and
+# Docker are the only requirements. That matters because a NAS or appliance OS is often
+# neither macOS nor Ubuntu, and is exactly where the containerised install is most useful.
 if [[ "$OSTYPE" == "darwin"* ]]; then
     OS="macos"
 elif [[ -f /etc/os-release ]] && grep -qi 'ubuntu\|debian' /etc/os-release; then
     OS="ubuntu"
 else
-    die "Unsupported OS. This script supports macOS and Ubuntu/Debian."
+    OS="other"
+fi
+
+if [[ "$OS" == "other" && "$MODE" != "docker" ]]; then
+    die "Unsupported OS. The '$MODE' install supports macOS and Ubuntu/Debian."
 fi
 info "Detected OS: $OS"
 
@@ -86,6 +103,279 @@ systemd_start() {
         sudo systemctl enable --now "$svc"
     fi
 }
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Docker mode
+#
+# Writes .env and docker-compose.override.yml from answers, then optionally starts the
+# stack. Nothing else in this script runs afterwards: the image already carries Python,
+# exiftool, PostgreSQL and RabbitMQ, so there is nothing to install on the host.
+# ══════════════════════════════════════════════════════════════════════════════
+if [[ "$MODE" == "docker" ]]; then
+    ENV_FILE=".env"
+    OVERRIDE_FILE="docker-compose.override.yml"
+
+    # Prompts read from the terminal rather than stdin so the script still works when piped.
+    ask() {
+        local __var="$1" prompt="$2" default="$3" reply=""
+        if [[ -n "$default" ]]; then
+            read -r -p "  $prompt [$default]: " reply </dev/tty || true
+        else
+            read -r -p "  $prompt: " reply </dev/tty || true
+        fi
+        printf -v "$__var" '%s' "${reply:-$default}"
+    }
+
+    confirm() {
+        local reply=""
+        read -r -p "  $1 [Y/n]: " reply </dev/tty || true
+        [[ -z "$reply" || "$reply" =~ ^[Yy] ]]
+    }
+
+    # Existing answers become the defaults, so re-running to change one thing does not mean
+    # retyping the rest.
+    env_value() {
+        [[ -f "$ENV_FILE" ]] || return 0
+        grep -E "^$1=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2-
+    }
+
+    # env_value succeeds even when the key is absent, so a `||` fallback would never fire.
+    # This picks the fallback on empty output instead.
+    env_default() {
+        local value
+        value="$(env_value "$1")"
+        echo "${value:-$2}"
+    }
+
+    existing_photo_dirs() {
+        [[ -f "$OVERRIDE_FILE" ]] || return 0
+        grep -oE '^ +- [^:]+:[^:]+:ro$' "$OVERRIDE_FILE" 2>/dev/null \
+            | sed -E 's/^ +- ([^:]+):.*/\1/' | awk '!seen[$0]++'
+    }
+
+    detect_lan_ip() {
+        local ip=""
+        if command -v ip &>/dev/null; then
+            ip=$(ip -4 route get 1.1.1.1 2>/dev/null \
+                 | awk '{for (i = 1; i <= NF; i++) if ($i == "src") { print $(i + 1); exit }}')
+        fi
+        if [[ -z "$ip" ]] && command -v ipconfig &>/dev/null; then
+            ip=$(ipconfig getifaddr en0 2>/dev/null || true)
+        fi
+        if [[ -z "$ip" ]] && command -v hostname &>/dev/null; then
+            ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+        fi
+        echo "${ip:-localhost}"
+    }
+
+    cpu_count() {
+        if command -v nproc &>/dev/null; then
+            nproc
+        elif command -v sysctl &>/dev/null; then
+            sysctl -n hw.ncpu 2>/dev/null || echo 2
+        else
+            echo 2
+        fi
+    }
+
+    port_in_use() {
+        if command -v ss &>/dev/null; then
+            ss -tln 2>/dev/null | grep -q ":$1 "
+        elif command -v lsof &>/dev/null; then
+            lsof -iTCP:"$1" -sTCP:LISTEN &>/dev/null
+        else
+            return 1
+        fi
+    }
+
+    # Generated rather than prompted. openssl is present on macOS and Linux alike;
+    # /dev/urandom covers whatever is left, so the host never needs Python.
+    generate_secret() {
+        if command -v openssl &>/dev/null; then
+            openssl rand -base64 48 | tr -d '\n=+/' | cut -c1-50
+        else
+            head -c 64 /dev/urandom | base64 | tr -d '\n=+/' | cut -c1-50
+        fi
+    }
+
+    # ── Docker itself ──────────────────────────────────────────────────────────
+    info "Checking Docker..."
+    if ! command -v docker &>/dev/null; then
+        if [[ "$OS" == "ubuntu" ]]; then
+            echo ""
+            if confirm "Docker is not installed. Install docker.io and docker-compose-v2 now?"; then
+                sudo apt-get update -qq
+                apt_install docker.io
+                apt_install docker-compose-v2
+                if ! id -nG "$USER" | grep -qw docker; then
+                    info "Adding $USER to the docker group..."
+                    sudo usermod -aG docker "$USER"
+                fi
+                echo ""
+                info "Docker installed. Log out and back in for the group change to apply,"
+                info "then re-run './setup.sh docker'."
+                exit 0
+            fi
+            die "Docker is required for this mode."
+        elif [[ "$OS" == "macos" ]]; then
+            die "Docker is required. Install Docker Desktop from https://docker.com/products/docker-desktop"
+        else
+            die "Docker is required. Install it from your platform's package manager, or from the
+       container package your NAS provides."
+        fi
+    fi
+    skip "docker $(docker --version | awk '{print $3}' | tr -d ,) present"
+
+    if ! docker compose version &>/dev/null; then
+        die "Docker Compose v2 is required ('docker compose', not 'docker-compose').
+       On Ubuntu:  sudo apt install docker-compose-v2
+       Elsewhere:  update Docker to a release that ships Compose v2."
+    fi
+    skip "compose $(docker compose version --short 2>/dev/null || echo v2) present"
+
+    if ! docker info &>/dev/null; then
+        die "Cannot reach the Docker daemon. Is it running, and is $USER in the docker group?
+       Add yourself with:  sudo usermod -aG docker $USER   (then log out and back in)"
+    fi
+
+    # ── Questions ──────────────────────────────────────────────────────────────
+    echo ""
+    echo "  Answer the following. Defaults are in brackets; press enter to accept."
+    echo ""
+
+    [[ -f "$ENV_FILE" ]] && info "Reading existing $ENV_FILE for defaults"
+
+    ask FILMCASE_HOST "Address you will browse to" "$(env_default FILMCASE_HOST "$(detect_lan_ip)")"
+
+    ask HTTPS_PORT "HTTPS port" "$(env_default FILMCASE_HTTPS_PORT 8443)"
+    if port_in_use "$HTTPS_PORT"; then
+        echo ""
+        skip "Something is already listening on port $HTTPS_PORT."
+        confirm "Use it anyway?" || die "Re-run and choose a free port."
+    fi
+
+    ask PUID_ANSWER "User id to own the files" "$(env_default PUID "$(id -u)")"
+    ask PGID_ANSWER "Group id to own the files" "$(env_default PGID "$(id -g)")"
+
+    # Every worker process loads Django and Pillow, so the default stays modest: a NAS is
+    # usually running other things, and oversubscribing a small CPU costs more than it wins.
+    default_concurrency=$(cpu_count)
+    [[ "$default_concurrency" -gt 4 ]] && default_concurrency=4
+    ask CONCURRENCY "Celery worker processes" "$(env_default FILMCASE_WORKER_CONCURRENCY "$default_concurrency")"
+    ask WEB_WORKERS "Web server processes" "$(env_default FILMCASE_WEB_WORKERS 2)"
+
+    # ── Photo directories ──────────────────────────────────────────────────────
+    echo ""
+    echo "  Photo directories to import. They are mounted read-only, at the same path"
+    echo "  inside the container, so the path you type is the path you enter on the"
+    echo "  Library page. Enter one per line; blank line when done."
+    echo ""
+
+    PHOTO_DIRS=()
+    while IFS= read -r existing; do
+        if [[ -n "$existing" ]]; then
+            PHOTO_DIRS+=("$existing")
+            info "keeping $existing"
+        fi
+    done < <(existing_photo_dirs)
+
+    while true; do
+        ask photo_dir "Photo directory (blank to finish)" ""
+        [[ -z "$photo_dir" ]] && break
+        photo_dir="${photo_dir/#\~/$HOME}"
+        if [[ ! -d "$photo_dir" ]]; then
+            skip "not a directory: $photo_dir"
+            continue
+        fi
+        photo_dir="$(cd "$photo_dir" && pwd)"
+        if printf '%s\n' "${PHOTO_DIRS[@]:-}" | grep -qxF "$photo_dir"; then
+            skip "already added: $photo_dir"
+            continue
+        fi
+        PHOTO_DIRS+=("$photo_dir")
+        info "added $photo_dir"
+    done
+
+    if [[ ${#PHOTO_DIRS[@]} -eq 0 ]]; then
+        skip "No photo directories. Filmcase will start with an empty library, and you"
+        skip "will need to re-run this to add one before anything can be imported."
+    fi
+
+    # ── Write the files ────────────────────────────────────────────────────────
+    SECRET_KEY_VALUE="$(env_value FILMCASE_SECRET_KEY || true)"
+    if [[ -z "$SECRET_KEY_VALUE" || "$SECRET_KEY_VALUE" == "change-me" ]]; then
+        SECRET_KEY_VALUE="$(generate_secret)"
+    fi
+    DB_PASSWORD_VALUE="$(env_value FILMCASE_DB_PASSWORD || true)"
+    [[ -z "$DB_PASSWORD_VALUE" ]] && DB_PASSWORD_VALUE="$(generate_secret)"
+
+    cat > "$ENV_FILE" <<EOF
+# Generated by ./setup.sh docker on $(date +%Y-%m-%d). Re-run it to change these.
+
+FILMCASE_HOST=$FILMCASE_HOST
+FILMCASE_HTTPS_PORT=$HTTPS_PORT
+
+PUID=$PUID_ANSWER
+PGID=$PGID_ANSWER
+
+FILMCASE_WORKER_CONCURRENCY=$CONCURRENCY
+FILMCASE_WEB_WORKERS=$WEB_WORKERS
+
+FILMCASE_SECRET_KEY=$SECRET_KEY_VALUE
+FILMCASE_DB_PASSWORD=$DB_PASSWORD_VALUE
+EOF
+    info "Wrote $ENV_FILE"
+
+    {
+        echo "# Generated by ./setup.sh docker on $(date +%Y-%m-%d). Re-run it to change these."
+        echo "#"
+        echo "# Photo directories are mounted at their host paths so the values stored in"
+        echo "# LibraryFolder stay valid. Both services need them: the worker does the importing."
+        echo ""
+        echo "services:"
+        for service in web celery_worker; do
+            echo "  $service:"
+            if [[ ${#PHOTO_DIRS[@]} -eq 0 ]]; then
+                echo "    volumes: []"
+            else
+                echo "    volumes:"
+                for photo_dir in "${PHOTO_DIRS[@]}"; do
+                    echo "      - $photo_dir:$photo_dir:ro"
+                done
+            fi
+            [[ "$service" == "web" ]] && echo ""
+        done
+    } > "$OVERRIDE_FILE"
+    info "Wrote $OVERRIDE_FILE"
+
+    # ── Summary ────────────────────────────────────────────────────────────────
+    echo ""
+    echo "  Host        https://$FILMCASE_HOST:$HTTPS_PORT"
+    echo "  Owner       uid $PUID_ANSWER, gid $PGID_ANSWER"
+    echo "  Processes   $WEB_WORKERS web, $CONCURRENCY worker"
+    if [[ ${#PHOTO_DIRS[@]} -eq 0 ]]; then
+        echo "  Photos      none configured"
+    else
+        for photo_dir in "${PHOTO_DIRS[@]}"; do
+            echo "  Photos      $photo_dir (read-only)"
+        done
+    fi
+    echo ""
+    echo "  The certificate is self-signed, so your browser will warn once. That is"
+    echo "  expected: accepting it is what makes camera access work from the browser."
+    echo ""
+
+    if confirm "Build and start now?"; then
+        docker compose up -d --build
+        echo ""
+        info "Filmcase is starting at https://$FILMCASE_HOST:$HTTPS_PORT/"
+        info "Follow the log with: docker compose logs -f web"
+    else
+        echo ""
+        info "Start it whenever you like with: docker compose up -d --build"
+    fi
+    exit 0
+fi
 
 # ══════════════════════════════════════════════════════════════════════════════
 # 1. Python 3.11+

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -20,6 +20,22 @@ DEBUG: bool = env.bool("DEBUG", default=True)
 
 ALLOWED_HOSTS = ["*"]
 
+# The address the app is reached at. It has to match what users type, because it is written
+# into the container's self-signed certificate as a subjectAltName and reused below as the
+# trusted CSRF origin. A native install on the default runserver never leaves localhost, so
+# that is the default.
+FILMCASE_HOST: str = env.str("FILMCASE_HOST", default="localhost")
+FILMCASE_HTTPS_PORT: int = env.int("FILMCASE_HTTPS_PORT", default=8443)
+
+# Django rejects unsafe-method requests whose Origin is not listed here, and an HTTPS origin
+# never matches by accident: reaching the app on any address other than FILMCASE_HOST fails
+# every POST. Derived so there is one knob rather than two, and overridable outright for
+# installs reachable under several names.
+CSRF_TRUSTED_ORIGINS: list[str] = env.list(
+    "CSRF_TRUSTED_ORIGINS",
+    default=[f"https://{FILMCASE_HOST}:{FILMCASE_HTTPS_PORT}"],
+)
+
 INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.auth",

--- a/src/domain/camera/ptp_device.py
+++ b/src/domain/camera/ptp_device.py
@@ -11,6 +11,12 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
+# All Fujifilm cameras share this USB vendor ID.  It lives here rather than in a concrete
+# transport because callers that never open a USB connection still need it: the browser-side
+# camera diagnostics filter their device picker by vendor, and importing a private name out of
+# ptp_usb_device would couple the interface layer to one particular transport.
+FUJIFILM_VENDOR_ID = 0x04CB
+
 
 class CameraConnectionError(Exception):
     """

--- a/src/domain/camera/ptp_usb_device.py
+++ b/src/domain/camera/ptp_usb_device.py
@@ -38,12 +38,6 @@ if TYPE_CHECKING:
     pass
 
 # ---------------------------------------------------------------------------
-# Fujifilm USB identity
-# ---------------------------------------------------------------------------
-
-_FUJIFILM_VENDOR_ID = 0x04CB   # all Fujifilm cameras share this vendor ID
-
-# ---------------------------------------------------------------------------
 # PTP/USB packet types (PIMA 15740:2000 §5.3.1)
 # ---------------------------------------------------------------------------
 
@@ -285,7 +279,7 @@ class PTPUSBDevice:
             ptp_device.CameraConnectionError: If no camera is found, USB access is
                                    denied, or the PTP session cannot be opened.
         """
-        self._dev = usb.core.find(idVendor=_FUJIFILM_VENDOR_ID)
+        self._dev = usb.core.find(idVendor=ptp_device.FUJIFILM_VENDOR_ID)
         if self._dev is None:
             raise ptp_device.CameraConnectionError(
                 "No Fujifilm camera found via USB.\n"

--- a/src/interfaces/camera/urls.py
+++ b/src/interfaces/camera/urls.py
@@ -5,4 +5,5 @@ from src.interfaces.camera import views
 urlpatterns = [
     path("recipes/<int:recipe_id>/push/", views.SelectSlot.as_view(), name="select-push-slot"),
     path("recipes/<int:recipe_id>/push/<str:slot>/", views.PushRecipeToCamera.as_view(), name="push-recipe-to-camera"),
+    path("camera/diagnostics/", views.CameraDiagnostics.as_view(), name="camera-diagnostics"),
 ]

--- a/src/interfaces/camera/views.py
+++ b/src/interfaces/camera/views.py
@@ -1,3 +1,4 @@
+import attrs
 import structlog
 
 from django import http
@@ -102,3 +103,34 @@ class PushRecipeToCamera(generic.View):
         if is_htmx:
             return shortcuts.render(request, "recipes/_push_result_partial.html", {"success": True, "message": f"Recipe saved to {slot}"})
         return http.JsonResponse({"message": f"Recipe saved in {slot}"})
+
+
+@attrs.frozen
+class _DiagnosticsContext:
+    vendor_id: int
+    vendor_id_label: str
+
+    @classmethod
+    def build(cls) -> "_DiagnosticsContext":
+        return cls(
+            vendor_id=ptp_device.FUJIFILM_VENDOR_ID,
+            vendor_id_label=f"0x{ptp_device.FUJIFILM_VENDOR_ID:04X}",
+        )
+
+
+class CameraDiagnostics(generic.View):
+    """
+    Report whether this browser can reach a camera over WebUSB from this origin.
+
+    Every check runs in the browser, because the answer depends on where the page was
+    loaded from rather than on anything the server can determine: WebUSB is gated on a
+    secure context, so it is available over HTTPS and on localhost, and absent over plain
+    HTTP to a LAN address no matter which machine the camera is plugged into.
+    """
+
+    def get(self, request: http.HttpRequest) -> http.HttpResponse:
+        return shortcuts.render(
+            request,
+            "camera/diagnostics.html",
+            {"diagnostics": _DiagnosticsContext.build(), "active_section": "camera"},
+        )

--- a/src/interfaces/templates/camera/diagnostics.html
+++ b/src/interfaces/templates/camera/diagnostics.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Camera Diagnostics</title>
+  <link rel="stylesheet" href="/static/css/brand.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { display: flex; flex-direction: column; font-family: sans-serif; min-height: 100vh; background: var(--color-bg-page); }
+
+    .main-content { flex: 1; padding: 2rem; max-width: 820px; }
+
+    .page-title { font-size: 1.25rem; font-weight: 700; color: var(--color-text-primary); margin-bottom: 0.35rem; }
+    .page-intro { font-size: 0.875rem; color: #6b7280; line-height: 1.5; margin-bottom: 1.75rem; }
+
+    .section-title { font-size: 0.95rem; font-weight: 600; color: var(--color-text-primary); margin: 1.75rem 0 0.75rem; }
+
+    .check-list { list-style: none; border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; }
+
+    .check {
+      display: flex;
+      align-items: baseline;
+      gap: 0.75rem;
+      padding: 0.7rem 1rem;
+      background: var(--color-bg-surface);
+      border-bottom: 1px solid var(--color-border);
+      font-size: 0.875rem;
+    }
+
+    .check:last-child { border-bottom: none; }
+
+    .check__label { flex: 0 0 13rem; color: var(--color-text-primary); font-weight: 500; }
+    .check__value { flex: 1; color: #4b5563; font-family: ui-monospace, monospace; font-size: 0.8125rem; word-break: break-all; }
+
+    .pill {
+      flex: 0 0 auto;
+      padding: 0.1rem 0.5rem;
+      border-radius: 999px;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+    }
+
+    .pill--pass    { background: #dcfce7; color: #15803d; }
+    .pill--fail    { background: #fee2e2; color: #b91c1c; }
+    .pill--waiting { background: #f3f4f6; color: #6b7280; }
+    .pill--warn    { background: #fef3c7; color: #b45309; }
+
+    .probe-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      margin-top: 1rem;
+      padding: 0.45rem 1rem;
+      background: var(--color-accent);
+      color: #fff;
+      border: none;
+      border-radius: 5px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+
+    .probe-btn:hover:enabled { background: var(--color-accent-dark); }
+    .probe-btn:disabled { background: #d1d5db; cursor: not-allowed; }
+
+    .note {
+      padding: 0.8rem 1rem;
+      margin-top: 1.5rem;
+      background: #fffbeb;
+      border: 1px solid #fde68a;
+      border-radius: 6px;
+      color: #92400e;
+      font-size: 0.8125rem;
+      line-height: 1.55;
+    }
+
+    .note--blocked { background: #fef2f2; border-color: #fecaca; color: #b91c1c; }
+    .note p + p { margin-top: 0.5rem; }
+    .note code { font-family: ui-monospace, monospace; font-size: 0.78125rem; }
+  </style>
+</head>
+<body>
+  {% include "_top_nav.html" %}
+
+  <main class="main-content">
+    <h1 class="page-title">Camera diagnostics</h1>
+    <p class="page-intro">
+      Whether this browser can talk to a camera over USB depends on the address this page was
+      loaded from, not on which machine the camera is plugged into. Browsers only expose USB to
+      a <strong>secure context</strong>: an HTTPS origin, or localhost. Plain HTTP to a LAN
+      address never qualifies, even when the camera is on the same desk.
+    </p>
+
+    <h2 class="section-title">This page</h2>
+    <ul class="check-list">
+      <li class="check">
+        <span class="check__label">Origin</span>
+        <span class="check__value" id="check-origin">…</span>
+        <span class="pill pill--waiting" id="pill-origin">checking</span>
+      </li>
+      <li class="check">
+        <span class="check__label">Secure context</span>
+        <span class="check__value" id="check-secure">…</span>
+        <span class="pill pill--waiting" id="pill-secure">checking</span>
+      </li>
+      <li class="check">
+        <span class="check__label">WebUSB available</span>
+        <span class="check__value" id="check-webusb">…</span>
+        <span class="pill pill--waiting" id="pill-webusb">checking</span>
+      </li>
+    </ul>
+
+    <div id="environment-note"></div>
+
+    <h2 class="section-title">Camera</h2>
+    <p class="page-intro" style="margin-bottom: 0.75rem;">
+      Picking a device needs a click, so this cannot run automatically. Connect the camera by
+      USB, set it to PC Connection or RAW CONV. mode, then run the probe and choose it from the
+      browser's picker.
+    </p>
+
+    <ul class="check-list">
+      <li class="check">
+        <span class="check__label">Device selected</span>
+        <span class="check__value" id="check-device">not run</span>
+        <span class="pill pill--waiting" id="pill-device">waiting</span>
+      </li>
+      <li class="check">
+        <span class="check__label">Opened</span>
+        <span class="check__value" id="check-open">not run</span>
+        <span class="pill pill--waiting" id="pill-open">waiting</span>
+      </li>
+      <li class="check">
+        <span class="check__label">Bulk endpoints</span>
+        <span class="check__value" id="check-endpoints">not run</span>
+        <span class="pill pill--waiting" id="pill-endpoints">waiting</span>
+      </li>
+      <li class="check">
+        <span class="check__label">Interface claimed</span>
+        <span class="check__value" id="check-claim">not run</span>
+        <span class="pill pill--waiting" id="pill-claim">waiting</span>
+      </li>
+    </ul>
+
+    <button class="probe-btn" id="probe-btn" type="button" disabled>Probe camera</button>
+    <button class="probe-btn" id="probe-all-btn" type="button" disabled
+            style="background: transparent; color: var(--color-accent); border: 1px solid var(--color-border);">
+      Probe without vendor filter
+    </button>
+
+    <div class="note">
+      <p>
+        <strong>If claiming fails, something else already holds the camera.</strong> On Linux
+        that is usually <code>gvfs-gphoto2-volume-monitor</code>, which mounts PTP cameras the
+        moment they are plugged in. On macOS it is Photos, and on Windows the device is claimed
+        as MTP. The browser cannot evict any of them, so the fix is on the host and is the same
+        one the server-side path needs: see <code>docs/camera_usb_access.md</code>.
+      </p>
+      <p>
+        Selecting a device also needs permission on the raw USB node. On Linux that normally
+        arrives with libgphoto2, whose udev rules give every still-image class device to the
+        <code>plugdev</code> group. Installing libgphoto2 for its rules while disabling its
+        automount is the combination that works.
+      </p>
+      <p>
+        Filtering by vendor <code>{{ diagnostics.vendor_id_label }}</code> hides non-Fujifilm
+        devices from the picker. If the camera does not appear, run the unfiltered probe to see
+        whether the browser can see it at all.
+      </p>
+    </div>
+  </main>
+
+  <script>
+    (function () {
+      "use strict";
+
+      const FUJIFILM_VENDOR_ID = {{ diagnostics.vendor_id }};
+
+      function setCheck(name, value, state) {
+        document.getElementById("check-" + name).textContent = value;
+        const pill = document.getElementById("pill-" + name);
+        pill.className = "pill pill--" + state;
+        pill.textContent = state === "pass" ? "pass"
+                         : state === "fail" ? "fail"
+                         : state === "warn" ? "partial"
+                         : "waiting";
+      }
+
+      function showEnvironmentNote(html, blocked) {
+        const container = document.getElementById("environment-note");
+        container.innerHTML =
+          '<div class="note' + (blocked ? " note--blocked" : "") + '">' + html + "</div>";
+      }
+
+      // The environment checks are all synchronous reads, so they run on load. The probe
+      // itself needs a user gesture: requestDevice() throws without one.
+      const secure = window.isSecureContext;
+      const hasWebUsb = "usb" in navigator;
+
+      setCheck("origin", window.location.origin, "pass");
+      setCheck("secure", secure ? "true" : "false", secure ? "pass" : "fail");
+      setCheck("webusb", hasWebUsb ? "navigator.usb present" : "navigator.usb missing",
+               hasWebUsb ? "pass" : "fail");
+
+      if (!secure) {
+        showEnvironmentNote(
+          "<p><strong>This origin is not a secure context, so USB access is unavailable.</strong> " +
+          "Reach Filmcase over HTTPS, or over <code>http://localhost</code> when it runs on this " +
+          "machine. A self-signed certificate is enough: the browser checks the scheme, not " +
+          "whether the certificate is trusted, so accepting the warning once is sufficient.</p>" +
+          "<p>Private addresses such as <code>http://192.168.x.x</code> are never trusted, and no " +
+          "browser flag worth shipping changes that.</p>",
+          true
+        );
+      } else if (!hasWebUsb) {
+        showEnvironmentNote(
+          "<p><strong>This origin is secure, but the browser has no WebUSB support.</strong> " +
+          "WebUSB is Chromium-only: Chrome, Edge, Opera and Brave have it, Firefox and Safari " +
+          "do not. Try the same address in a Chromium browser.</p>",
+          true
+        );
+      } else {
+        document.getElementById("probe-btn").disabled = false;
+        document.getElementById("probe-all-btn").disabled = false;
+      }
+
+      // Mirrors _claim_interface in ptp_usb_device.py: PTP needs one bulk endpoint in each
+      // direction, and the interface that carries them is the one worth claiming.
+      function findBulkInterface(device) {
+        const configuration = device.configuration;
+        if (!configuration) {
+          return null;
+        }
+        for (const iface of configuration.interfaces) {
+          for (const alternate of iface.alternates) {
+            const directions = alternate.endpoints
+              .filter(function (e) { return e.type === "bulk"; })
+              .map(function (e) { return e.direction; });
+            if (directions.includes("in") && directions.includes("out")) {
+              return { number: iface.interfaceNumber, endpoints: alternate.endpoints.length };
+            }
+          }
+        }
+        return null;
+      }
+
+      async function probe(filtered) {
+        ["device", "open", "endpoints", "claim"].forEach(function (name) {
+          setCheck(name, "not run", "waiting");
+        });
+
+        let device;
+        try {
+          const options = filtered
+            ? { filters: [{ vendorId: FUJIFILM_VENDOR_ID }] }
+            : { filters: [] };
+          device = await navigator.usb.requestDevice(options);
+        } catch (error) {
+          const cancelled = error.name === "NotFoundError";
+          setCheck("device", cancelled ? "no device chosen" : error.name + ": " + error.message,
+                   cancelled ? "waiting" : "fail");
+          return;
+        }
+
+        const vendor = "0x" + device.vendorId.toString(16).toUpperCase().padStart(4, "0");
+        const product = "0x" + device.productId.toString(16).toUpperCase().padStart(4, "0");
+        const name = [device.manufacturerName, device.productName].filter(Boolean).join(" ");
+        setCheck("device", (name || "unnamed device") + "  vendor " + vendor + " product " + product,
+                 device.vendorId === FUJIFILM_VENDOR_ID ? "pass" : "warn");
+
+        try {
+          await device.open();
+          if (device.configuration === null) {
+            await device.selectConfiguration(1);
+          }
+          setCheck("open", "configuration " + device.configuration.configurationValue, "pass");
+        } catch (error) {
+          setCheck("open", error.name + ": " + error.message, "fail");
+          return;
+        }
+
+        const target = findBulkInterface(device);
+        if (target === null) {
+          setCheck("endpoints", "no interface exposes bulk in and out", "fail");
+          await device.close();
+          return;
+        }
+        setCheck("endpoints",
+                 "interface " + target.number + ", " + target.endpoints + " endpoints", "pass");
+
+        try {
+          await device.claimInterface(target.number);
+          setCheck("claim", "claimed interface " + target.number, "pass");
+          await device.releaseInterface(target.number);
+        } catch (error) {
+          setCheck("claim", error.name + ": " + error.message, "fail");
+        } finally {
+          await device.close();
+        }
+      }
+
+      document.getElementById("probe-btn")
+        .addEventListener("click", function () { probe(true); });
+      document.getElementById("probe-all-btn")
+        .addEventListener("click", function () { probe(false); });
+    })();
+  </script>
+</body>
+</html>

--- a/tests/functional/test_camera_diagnostics_view.py
+++ b/tests/functional/test_camera_diagnostics_view.py
@@ -1,0 +1,33 @@
+from src.domain.camera import ptp_device
+
+
+class TestCameraDiagnostics:
+    def test_renders_the_diagnostics_page(self, client):
+        response = client.get("/camera/diagnostics/")
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "Camera diagnostics" in content
+
+    def test_exposes_the_fujifilm_vendor_id_to_the_probe_script(self, client):
+        response = client.get("/camera/diagnostics/")
+
+        content = response.content.decode()
+        assert f"const FUJIFILM_VENDOR_ID = {ptp_device.FUJIFILM_VENDOR_ID};" in content
+
+    def test_labels_the_vendor_id_in_hexadecimal_for_the_reader(self, client):
+        response = client.get("/camera/diagnostics/")
+
+        assert f"0x{ptp_device.FUJIFILM_VENDOR_ID:04X}" in response.content.decode()
+
+    def test_highlights_the_camera_section_in_the_navigation(self, client):
+        response = client.get("/camera/diagnostics/")
+
+        assert "top-nav__link--active" in response.content.decode()
+
+    def test_reports_every_probe_step_the_push_path_depends_on(self, client):
+        response = client.get("/camera/diagnostics/")
+
+        content = response.content.decode()
+        for check_id in ("check-secure", "check-webusb", "check-open", "check-endpoints", "check-claim"):
+            assert check_id in content


### PR DESCRIPTION
## Why

Filmcase has to run on the machine you are sitting at. Putting it on a NAS or any
always-on server means installing Python, PostgreSQL, RabbitMQ and exiftool by hand, and
`setup.sh` only supports macOS and Ubuntu, which most of those machines are not.

Serving it from another machine also raises a question the app has never had to answer.
Browsers expose USB, and several other capabilities, only to a secure context, so a plain
HTTP LAN address would foreclose ever moving the camera transport into the browser.

## How

A third install mode alongside lite and full, configured in one command:

```bash
./setup.sh docker
```

- **No file editing.** It asks for the address, the photo directories and the process
  counts, filling in the LAN address, user id and core count as defaults, generates the
  signing key and database password, writes `.env` and `docker-compose.override.yml`, and
  offers to build and start. Re-running it changes one answer without retyping the rest,
  and preserves the generated secrets rather than rotating them.
- **Runs where the other modes cannot.** It installs nothing on the host, so it needs only
  bash and Docker rather than a recognised operating system.
- **Served over HTTPS**, with a self-signed certificate generated on first start. That is
  enough to reach a secure context, because the browser checks the origin's scheme rather
  than whether the chain is trusted, at the cost of one interstitial per browser.
- **Photo directories mount at their host paths**, so the paths stored in `LibraryFolder`
  stay valid and a library survives moving between a Docker and a native install.

Pushing recipes still reads the camera from the machine running the server, so it does not
work on a remote install yet. I added a diagnostics page that confirms the browser side is viable though, so an implementation of a front-end ptp library is on the works to make the docker version 100% compatible.


It solves #59 