### PR TITLE
Fix rabbitmq 4 celery queues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
     restart: unless-stopped
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+      # Read alongside the image's own rabbitmq.conf rather than replacing it.
+      - ./docker/rabbitmq.conf:/etc/rabbitmq/conf.d/10-filmcase.conf:ro
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
       interval: 10s

--- a/docker/rabbitmq.conf
+++ b/docker/rabbitmq.conf
@@ -1,0 +1,12 @@
+# RabbitMQ 4 deprecated transient non-durable, non-exclusive classic queues and stopped
+# permitting them by default. Celery needs them in two places, so without this the broker
+# rejects every Queue.declare with INTERNAL_ERROR (541) and no image can be imported at all:
+#
+#   - the pidbox reply queue behind control.inspect().ping(), which the Library page uses to
+#     check a worker is reachable before starting a sync
+#   - the reply queue created by the rpc:// result backend
+#
+# Permitting the feature is RabbitMQ's own supported escape hatch while applications
+# migrate. Remove this once Celery declares those queues durable or exclusive, at which
+# point the setting becomes a no-op and can go with the file.
+deprecated_features.permit.transient_nonexcl_queues = true

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -170,6 +170,9 @@ LOGGING = {
             "()": structlog.stdlib.ProcessorFormatter,
             "processor": structlog.processors.JSONRenderer(),
         },
+        "traceback": {
+            "format": "[%(asctime)s] %(levelname)s %(name)s: %(message)s",
+        },
     },
     "handlers": {
         "file": {
@@ -181,6 +184,12 @@ LOGGING = {
             "class": "logging.StreamHandler",
             "formatter": "console",
         },
+        # Plain stdlib formatting rather than the structlog renderer, so an exception's
+        # traceback reaches the container log verbatim.
+        "traceback_console": {
+            "class": "logging.StreamHandler",
+            "formatter": "traceback",
+        },
     },
     "loggers": {
         "events": {
@@ -191,6 +200,15 @@ LOGGING = {
         "camera.events": {
             "handlers": ["file", "console"],
             "level": "INFO",
+            "propagate": False,
+        },
+        # Django's own default sends unhandled view exceptions to a console handler gated on
+        # DEBUG, and to mail_admins, which needs email configured. With DEBUG off and no
+        # ADMINS, as in the container, a 500 is logged nowhere at all and the browser shows
+        # only Django's stock error page. Route it somewhere it can actually be read.
+        "django.request": {
+            "handlers": ["file", "traceback_console"],
+            "level": "ERROR",
             "propagate": False,
         },
     },


### PR DESCRIPTION
## Why

The containerised install could not import anything. RabbitMQ 4 stopped permitting the
transient queues Celery needs for `inspect().ping()` and the `rpc://` result backend, so
every `Queue.declare` failed and adding or editing a library folder returned a 500.

The 500 was invisible: with `DEBUG` off and no `ADMINS`, Django logs unhandled exceptions
nowhere.

## How

- **Permit the deprecated feature** in a `rabbitmq.conf` mounted into the broker's `conf.d`.
- **Send `django.request` to stderr** with a plain formatter, so tracebacks reach the log.
