### PR TITLE
Give gunicorn threads so one worker is not one request at a time

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,15 @@ FILMCASE_HTTPS_PORT=8443
 PUID=1000
 PGID=1000
 
-# Process counts. Each Celery process loads Django and Pillow, so on a small server keep
-# this near the core count rather than above it.
+# Web concurrency is workers times threads. Threads are the cheaper of the two, since each
+# worker is a whole Python process while threads share one, and the workload is dominated by
+# waiting on the database and the filesystem.
 FILMCASE_WEB_WORKERS=2
+FILMCASE_WEB_THREADS=4
+
+# How many photos are processed at once. This is Celery's --concurrency, the pool inside a
+# single worker, not a number of workers. Each process loads Django and Pillow, so on a
+# small server keep it near the core count rather than above it.
 FILMCASE_WORKER_CONCURRENCY=4
 
 # Django signing key. Generate one with:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -103,11 +103,17 @@ case "${1:-web}" in
         fi
 
         log "Starting gunicorn on https://$FILMCASE_HOST:$FILMCASE_HTTPS_PORT/"
+        # --threads matters more than --workers here. gunicorn's default sync worker serves
+        # exactly one request at a time, so a single worker without threads is markedly less
+        # concurrent than the threaded runserver a native install runs, and any slow request
+        # stalls the whole site. Passing --threads switches gunicorn to its gthread worker,
+        # restoring the model Django is already run under everywhere else.
         run_as_app_user gunicorn src.config.wsgi:application \
             --bind "0.0.0.0:$FILMCASE_HTTPS_PORT" \
             --certfile "$CERT_FILE" \
             --keyfile "$KEY_FILE" \
-            --workers "${FILMCASE_WEB_WORKERS:-3}" \
+            --workers "${FILMCASE_WEB_WORKERS:-2}" \
+            --threads "${FILMCASE_WEB_THREADS:-4}" \
             --timeout "${FILMCASE_WEB_TIMEOUT:-120}" \
             --access-logfile -
         ;;

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,15 +39,16 @@ tracked as a reference if you would rather write them by hand.
 
 Compose reads `.env` from the same directory. `.env.example` is the template.
 
-| Variable                | Default              | Purpose                                                        |
-| ----------------------- | -------------------- | -------------------------------------------------------------- |
-| `FILMCASE_HOST`         | `localhost`          | Address you type in the browser. Goes into the certificate SAN and the trusted CSRF origin. |
-| `FILMCASE_HTTPS_PORT`   | `8443`               | Published port.                                                |
-| `PUID` / `PGID`         | `1000` / `1000`      | Account that owns the volumes and runs the app.                |
-| `FILMCASE_WEB_WORKERS`  | `3`                  | gunicorn processes.                                            |
-| `FILMCASE_WORKER_CONCURRENCY` | `8`            | Celery processes. Each loads Django and Pillow, so keep it near the core count on a server that is running other things. |
-| `FILMCASE_SECRET_KEY`   | insecure dev default | Django signing key. Generate one before exposing the app.      |
-| `FILMCASE_DB_PASSWORD`  | `fujifilm_recipes`   | PostgreSQL password, reachable only inside the compose network. Changing it after first start locks the app out of the existing volume. |
+| Variable                      | Default              | Purpose                                                                                                                                 |
+| ----------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `FILMCASE_HOST`               | `localhost`          | Address you type in the browser. Goes into the certificate SAN and the trusted CSRF origin.                                             |
+| `FILMCASE_HTTPS_PORT`         | `8443`               | Published port.                                                                                                                         |
+| `PUID` / `PGID`               | `1000` / `1000`      | Account that owns the volumes and runs the app.                                                                                         |
+| `FILMCASE_WEB_WORKERS`        | `2`                  | gunicorn processes.                                                                                                                     |
+| `FILMCASE_WEB_THREADS`        | `4`                  | Threads per gunicorn process. Simultaneous requests is workers times threads.                                                           |
+| `FILMCASE_WORKER_CONCURRENCY` | `8`                  | Photos processed at once. This is Celery's `--concurrency`, the pool inside one worker, not a count of workers. Each process loads Django and Pillow, so keep it near the core count on a server running other things. |
+| `FILMCASE_SECRET_KEY`         | insecure dev default | Django signing key. Generate one before exposing the app.                                                                               |
+| `FILMCASE_DB_PASSWORD`        | `fujifilm_recipes`   | PostgreSQL password, reachable only inside the compose network. Changing it after first start locks the app out of the existing volume. |
 
 `FILMCASE_HOST` must match what you actually type. It is written into the certificate as a
 `subjectAltName` and reused to derive `CSRF_TRUSTED_ORIGINS`, so reaching the app on any
@@ -94,15 +95,15 @@ hands it to gunicorn. Your browser will show a full-page warning the first time,
 lines of "Your connection is not private". Accept it once per browser and the app works
 normally afterwards.
 
-**Why not plain HTTP?** Browsers gate powerful APIs behind a *secure context*, and the
+**Why not plain HTTP?** Browsers gate powerful APIs behind a _secure context_, and the
 check is on the origin's scheme, not on whether the certificate chains to a trusted
 authority. So:
 
-| Origin                        | Secure context | Powerful APIs |
-| ----------------------------- | -------------- | ------------- |
-| `http://localhost:8443`       | yes            | available     |
-| `https://192.168.1.10:8443` with a self-signed certificate | yes, after accepting the warning | available |
-| `http://192.168.1.10:8443`    | no             | unavailable   |
+| Origin                                                     | Secure context                   | Powerful APIs |
+| ---------------------------------------------------------- | -------------------------------- | ------------- |
+| `http://localhost:8443`                                    | yes                              | available     |
+| `https://192.168.1.10:8443` with a self-signed certificate | yes, after accepting the warning | available     |
+| `http://192.168.1.10:8443`                                 | no                               | unavailable   |
 
 A self-signed certificate is therefore enough. Private IP addresses are never treated as
 trustworthy on their own, and that has not changed despite a


### PR DESCRIPTION
A native install runs Django's runserver, which is threaded and serves many requests at once from a single process. gunicorn's default sync worker serves exactly one, so the obvious reading of FILMCASE_WEB_WORKERS, that one process is enough because one runserver always was, produced a web server markedly less concurrent than the development one.

It shows up worst where it hurts most: trigger_folder_sync runs the folder scan inline in the request, so on a single sync worker adding a library folder blocks every other request, including the status poll meant to show progress. The app looks hung rather than busy.

Passing --threads switches gunicorn to its gthread worker and restores the model Django is already run under. Verified against the built image, which logs "Using worker: sync" without the flag and "Using worker: gthread" with it. The default worker count drops to 2, since threads now supply the concurrency that extra processes were standing in for.