### PR TITLE
Pass the tuning variables into the containers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ FILMCASE_WEB_THREADS=4
 # small server keep it near the core count rather than above it.
 FILMCASE_WORKER_CONCURRENCY=4
 
+# Images per Celery message. Parallelism is capped at the number of messages, so with a
+# large worker pool a high batch size leaves most of it idle.
+SYNC_IMAGE_BATCH_SIZE=100
+
 # Django signing key. Generate one with:
 #
 #   openssl rand -base64 48

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,14 @@ x-filmcase-env: &filmcase-env
   FILMCASE_HTTPS_PORT: ${FILMCASE_HTTPS_PORT:-8443}
   PUID: ${PUID:-1000}
   PGID: ${PGID:-1000}
+  # Every value the container needs has to be named here. Compose reads .env only to
+  # interpolate ${...} into this file; it does not forward the file's contents into the
+  # containers. A tuning value written to .env but absent from this block is silently
+  # ignored, and the entrypoint quietly uses its own default instead.
+  FILMCASE_WEB_WORKERS: ${FILMCASE_WEB_WORKERS:-2}
+  FILMCASE_WEB_THREADS: ${FILMCASE_WEB_THREADS:-4}
+  FILMCASE_WORKER_CONCURRENCY: ${FILMCASE_WORKER_CONCURRENCY:-8}
+  SYNC_IMAGE_BATCH_SIZE: ${SYNC_IMAGE_BATCH_SIZE:-100}
   DB_ENGINE: django.db.backends.postgresql
   DB_NAME: fujifilm_recipes
   DB_USER: fujifilm_recipes

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -47,6 +47,7 @@ Compose reads `.env` from the same directory. `.env.example` is the template.
 | `FILMCASE_WEB_WORKERS`        | `2`                  | gunicorn processes.                                                                                                                     |
 | `FILMCASE_WEB_THREADS`        | `4`                  | Threads per gunicorn process. Simultaneous requests is workers times threads.                                                           |
 | `FILMCASE_WORKER_CONCURRENCY` | `8`                  | Photos processed at once. This is Celery's `--concurrency`, the pool inside one worker, not a count of workers. Each process loads Django and Pillow, so keep it near the core count on a server running other things. |
+| `SYNC_IMAGE_BATCH_SIZE`       | `100`                | Images per Celery message. Parallelism is capped at total images divided by this, so on a large pool lower it or most workers sit idle.                    |
 | `FILMCASE_SECRET_KEY`         | insecure dev default | Django signing key. Generate one before exposing the app.                                                                               |
 | `FILMCASE_DB_PASSWORD`        | `fujifilm_recipes`   | PostgreSQL password, reachable only inside the compose network. Changing it after first start locks the app out of the existing volume. |
 


### PR DESCRIPTION
## Why

`FILMCASE_WEB_WORKERS`, `FILMCASE_WEB_THREADS` and `FILMCASE_WORKER_CONCURRENCY` were never
listed in the compose environment, so none of them reached a container. Compose reads `.env`
only to interpolate `${...}` into the compose file itself; it does not forward that file's
contents to services. The entrypoint always fell back to its own defaults.

Worse than an ignored setting: `setup.sh` asks for these values, writes them to `.env` and
reports them back, and `docs/docker.md` presents them as the way to tune an install. The
Celery banner didn't reveal it either, because the entrypoint's default happened to match
the value being tested.

## How

- **List the three variables in the compose environment**, with the same defaults.
- **Add `SYNC_IMAGE_BATCH_SIZE`**, already an env-backed setting and worth reaching:
  parallelism is capped at the number of messages, so at the default of 100 a worker pool
  larger than the batch count sits partly idle whatever concurrency says.
