### PR TITLE
Settings section refactor

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -167,7 +167,7 @@ The image ships `libusb` for that second case. It is unused in browser mode.
 
 ### Checking what your browser can do
 
-`https://<FILMCASE_HOST>:8443/camera/diagnostics/` reports whether the page is a secure
+`https://<FILMCASE_HOST>:8443/settings/camera-diagnostics/` reports whether the page is a secure
 context, whether the browser exposes WebUSB, and whether it can select, open and claim the
 camera, and whether it can open a PTP session and read the model name. Run it before
 switching `CAMERA_TRANSPORT` to `browser`: it answers in one click whether this address and

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -5,10 +5,10 @@ from django.views.static import serve as static_serve
 
 from src.interfaces.camera.urls import urlpatterns as camera_urlpatterns
 from src.interfaces.images.urls import urlpatterns as image_urlpatterns
-from src.interfaces.library.urls import urlpatterns as library_urlpatterns
 from src.interfaces.recipes.urls import urlpatterns as recipe_urlpatterns
+from src.interfaces.settings.urls import urlpatterns as settings_urlpatterns
 
 urlpatterns = [
     path("static/<path:path>", static_serve, {"document_root": settings.STATIC_FILES_DIR}),
     path("", RedirectView.as_view(pattern_name="recipes-explorer"), name="root"),
-] + image_urlpatterns + recipe_urlpatterns + camera_urlpatterns + library_urlpatterns
+] + image_urlpatterns + recipe_urlpatterns + camera_urlpatterns + settings_urlpatterns

--- a/src/interfaces/camera/urls.py
+++ b/src/interfaces/camera/urls.py
@@ -5,7 +5,6 @@ from src.interfaces.camera import views
 urlpatterns = [
     path("recipes/<int:recipe_id>/push/", views.SelectSlot.as_view(), name="select-push-slot"),
     path("recipes/<int:recipe_id>/push/<str:slot>/", views.PushRecipeToCamera.as_view(), name="push-recipe-to-camera"),
-    path("camera/diagnostics/", views.CameraDiagnostics.as_view(), name="camera-diagnostics"),
     path("camera/client-config.json", views.CameraClientConfig.as_view(), name="camera-client-config"),
     path("recipes/<int:recipe_id>/camera-payload.json", views.RecipeCameraPayload.as_view(), name="recipe-camera-payload"),
 ]

--- a/src/interfaces/camera/views.py
+++ b/src/interfaces/camera/views.py
@@ -224,5 +224,5 @@ class CameraDiagnostics(generic.View):
         return shortcuts.render(
             request,
             "camera/diagnostics.html",
-            {"diagnostics": _DiagnosticsContext.build(), "active_section": "camera"},
+            {"diagnostics": _DiagnosticsContext.build(), "active_tab": "camera-diagnostics"},
         )

--- a/src/interfaces/library/urls.py
+++ b/src/interfaces/library/urls.py
@@ -3,14 +3,14 @@ from django.urls import path
 from src.interfaces.library import views
 
 urlpatterns = [
-    path("library/", views.LibraryFolderList.as_view(), name="library-list"),
-    path("library/new/", views.LibraryFolderAdd.as_view(), name="library-folder-new"),
-    path("library/browse/partial/", views.FilesystemBrowser.as_view(), name="library-browse"),
-    path("library/<int:folder_id>/confirm-delete/", views.LibraryFolderRemoveConfirm.as_view(), name="library-folder-confirm-delete"),
-    path("library/<int:folder_id>/delete/", views.LibraryFolderRemove.as_view(), name="library-folder-delete"),
-    path("library/<int:folder_id>/edit/", views.LibraryFolderPathUpdate.as_view(), name="library-folder-edit"),
-    path("library/<int:folder_id>/ignored/", views.LibraryFolderIgnoredImages.as_view(), name="library-folder-ignored"),
-    path("library/<int:folder_id>/ignored/retry/", views.LibraryFolderIgnoredImagesRetry.as_view(), name="library-folder-ignored-retry"),
-    path("library/ignored/<int:ignored_id>/retry/", views.LibraryIgnoredImageRetry.as_view(), name="library-ignored-retry"),
-    path("library/<int:folder_id>/sync-status/", views.LibraryFolderSyncStatus.as_view(), name="library-folder-sync-status"),
+    path("", views.LibraryFolderList.as_view(), name="library-list"),
+    path("new/", views.LibraryFolderAdd.as_view(), name="library-folder-new"),
+    path("browse/partial/", views.FilesystemBrowser.as_view(), name="library-browse"),
+    path("<int:folder_id>/confirm-delete/", views.LibraryFolderRemoveConfirm.as_view(), name="library-folder-confirm-delete"),
+    path("<int:folder_id>/delete/", views.LibraryFolderRemove.as_view(), name="library-folder-delete"),
+    path("<int:folder_id>/edit/", views.LibraryFolderPathUpdate.as_view(), name="library-folder-edit"),
+    path("<int:folder_id>/ignored/", views.LibraryFolderIgnoredImages.as_view(), name="library-folder-ignored"),
+    path("<int:folder_id>/ignored/retry/", views.LibraryFolderIgnoredImagesRetry.as_view(), name="library-folder-ignored-retry"),
+    path("ignored/<int:ignored_id>/retry/", views.LibraryIgnoredImageRetry.as_view(), name="library-ignored-retry"),
+    path("<int:folder_id>/sync-status/", views.LibraryFolderSyncStatus.as_view(), name="library-folder-sync-status"),
 ]

--- a/src/interfaces/library/views.py
+++ b/src/interfaces/library/views.py
@@ -40,6 +40,13 @@ def _list_all_folders() -> list[library_dataclasses.LibraryFolderData]:
     ]
 
 
+def _render_library_list(request: http.HttpRequest, *, error: str | None = None) -> http.HttpResponse:
+    context: dict[str, object] = {"folders": _list_all_folders(), "active_tab": "library"}
+    if error is not None:
+        context["error"] = error
+    return shortcuts.render(request, "library/library.html", context)
+
+
 def _sync_status(run: models.SyncRun) -> library_dataclasses.SyncRunData:
     total = run.total
     handled = run.processed + run.skipped + run.errors
@@ -71,7 +78,7 @@ class LibraryFolderList(generic.View):
     """Display the list of monitored library folders."""
 
     def get(self, request: http.HttpRequest) -> http.HttpResponse:
-        return shortcuts.render(request, "library/library.html", {"folders": _list_all_folders()})
+        return _render_library_list(request)
 
 
 class LibraryFolderAdd(generic.View):
@@ -84,23 +91,17 @@ class LibraryFolderAdd(generic.View):
         try:
             folder = add_library_folder_uc.add_library_folder(path=path)
         except add_library_folder_uc.FolderNotFound as exc:
-            return shortcuts.render(request, "library/library.html", {
-                "folders": _list_all_folders(),
-                "error": f"Folder does not exist: {exc.path}",
-            })
+            return _render_library_list(request, error=f"Folder does not exist: {exc.path}")
         except add_library_folder_uc.FolderAlreadyInLibrary as exc:
-            return shortcuts.render(request, "library/library.html", {
-                "folders": _list_all_folders(),
-                "error": f"Folder is already in the library: {exc.path}",
-            })
+            return _render_library_list(request, error=f"Folder is already in the library: {exc.path}")
 
         try:
             trigger_folder_sync_uc.trigger_folder_sync(folder_id=folder.folder_id)
         except trigger_folder_sync_uc.CeleryWorkerUnavailable:
-            return shortcuts.render(request, "library/library.html", {
-                "folders": _list_all_folders(),
-                "error": "Folder added, but no image worker is running to sync it. Start one with 'make worker'.",
-            })
+            return _render_library_list(
+                request,
+                error="Folder added, but no image worker is running to sync it. Start one with 'make worker'.",
+            )
         return shortcuts.redirect(urls.reverse("library-list"))
 
 
@@ -153,23 +154,17 @@ class LibraryFolderPathUpdate(generic.View):
         except update_library_folder_path_uc.LibraryFolderNotFound:
             raise http.Http404
         except update_library_folder_path_uc.FolderNotFound as exc:
-            return shortcuts.render(request, "library/library.html", {
-                "folders": _list_all_folders(),
-                "error": f"Folder does not exist: {exc.path}",
-            })
+            return _render_library_list(request, error=f"Folder does not exist: {exc.path}")
         except update_library_folder_path_uc.FolderAlreadyInLibrary as exc:
-            return shortcuts.render(request, "library/library.html", {
-                "folders": _list_all_folders(),
-                "error": f"Folder is already in the library: {exc.path}",
-            })
+            return _render_library_list(request, error=f"Folder is already in the library: {exc.path}")
 
         try:
             trigger_folder_sync_uc.trigger_folder_sync(folder_id=folder_id)
         except trigger_folder_sync_uc.CeleryWorkerUnavailable:
-            return shortcuts.render(request, "library/library.html", {
-                "folders": _list_all_folders(),
-                "error": "Path updated, but no image worker is running to sync it. Start one with 'make worker'.",
-            })
+            return _render_library_list(
+                request,
+                error="Path updated, but no image worker is running to sync it. Start one with 'make worker'.",
+            )
         return shortcuts.redirect(urls.reverse("library-list"))
 
 
@@ -275,6 +270,7 @@ class LibraryFolderIgnoredImages(generic.View):
         )
 
         return shortcuts.render(request, "library/ignored_images.html", {
+            "active_tab": "library",
             "folder": _folder_data(folder),
             "ignored_images": [_ignored_image_data(i) for i in page_obj],
             "page_obj": page_obj,

--- a/src/interfaces/settings/urls.py
+++ b/src/interfaces/settings/urls.py
@@ -1,0 +1,12 @@
+from django.urls import include, path
+from django.views.generic import RedirectView
+
+from src.interfaces.library.urls import urlpatterns as library_urlpatterns
+
+urlpatterns = [
+    # The settings landing has no page of its own yet, so it opens on the first tab.
+    path("settings/", RedirectView.as_view(pattern_name="library-list"), name="settings"),
+    # Mounted without a namespace so the library URL names stay flat and every
+    # existing {% url %} / reverse() reference keeps resolving unchanged.
+    path("settings/library/", include(library_urlpatterns)),
+]

--- a/src/interfaces/settings/urls.py
+++ b/src/interfaces/settings/urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 from django.views.generic import RedirectView
 
+from src.interfaces.camera import views as camera_views
 from src.interfaces.library.urls import urlpatterns as library_urlpatterns
 
 urlpatterns = [
@@ -9,4 +10,7 @@ urlpatterns = [
     # Mounted without a namespace so the library URL names stay flat and every
     # existing {% url %} / reverse() reference keeps resolving unchanged.
     path("settings/library/", include(library_urlpatterns)),
+    # The diagnostics page is a settings tab; the rest of the camera routes are
+    # not settings pages and stay under /camera/ and /recipes/.
+    path("settings/camera-diagnostics/", camera_views.CameraDiagnostics.as_view(), name="camera-diagnostics"),
 ]

--- a/src/interfaces/templates/_top_nav.html
+++ b/src/interfaces/templates/_top_nav.html
@@ -55,6 +55,5 @@
   </a>
   <a href="{% url 'recipes-explorer' %}" class="top-nav__link{% if active_section == 'recipes' %} top-nav__link--active{% endif %}">Recipes</a>
   <a href="{% url 'gallery' %}" class="top-nav__link{% if active_section == 'images' %} top-nav__link--active{% endif %}">Images</a>
-  <a class="top-nav__link{% if active_section == 'camera' %} top-nav__link--active{% endif %}">Camera</a>
   <a href="{% url 'settings' %}" class="top-nav__link{% if active_section == 'settings' %} top-nav__link--active{% endif %}">Settings</a>
 </nav>

--- a/src/interfaces/templates/_top_nav.html
+++ b/src/interfaces/templates/_top_nav.html
@@ -56,5 +56,5 @@
   <a href="{% url 'recipes-explorer' %}" class="top-nav__link{% if active_section == 'recipes' %} top-nav__link--active{% endif %}">Recipes</a>
   <a href="{% url 'gallery' %}" class="top-nav__link{% if active_section == 'images' %} top-nav__link--active{% endif %}">Images</a>
   <a class="top-nav__link{% if active_section == 'camera' %} top-nav__link--active{% endif %}">Camera</a>
-  <a href="{% url 'library-list' %}" class="top-nav__link{% if active_section == 'library' %} top-nav__link--active{% endif %}">Library</a>
+  <a href="{% url 'settings' %}" class="top-nav__link{% if active_section == 'settings' %} top-nav__link--active{% endif %}">Settings</a>
 </nav>

--- a/src/interfaces/templates/camera/diagnostics.html
+++ b/src/interfaces/templates/camera/diagnostics.html
@@ -1,15 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Camera Diagnostics</title>
-  <link rel="stylesheet" href="/static/css/brand.css">
-  <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { display: flex; flex-direction: column; font-family: sans-serif; min-height: 100vh; background: var(--color-bg-page); }
+{% extends "settings/base.html" %}
 
-    .main-content { flex: 1; padding: 2rem; max-width: 820px; }
+{% block title %}Camera Diagnostics{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .main-content { padding: 2rem; max-width: 820px; }
 
     .page-title { font-size: 1.25rem; font-weight: 700; color: var(--color-text-primary); margin-bottom: 0.35rem; }
     .page-intro { font-size: 0.875rem; color: #6b7280; line-height: 1.5; margin-bottom: 1.75rem; }
@@ -81,10 +76,9 @@
     .note p + p { margin-top: 0.5rem; }
     .note code { font-family: ui-monospace, monospace; font-size: 0.78125rem; }
   </style>
-</head>
-<body>
-  {% include "_top_nav.html" %}
+{% endblock %}
 
+{% block settings_content %}
   <main class="main-content">
     <h1 class="page-title">Camera diagnostics</h1>
     <p class="page-intro">
@@ -177,7 +171,9 @@
       </p>
     </div>
   </main>
+{% endblock %}
 
+{% block extra_scripts %}
   <script type="module">
     import {
       ClientPTPUSBDevice,
@@ -345,5 +341,4 @@
         .addEventListener("click", function () { probe(false); });
     })();
   </script>
-</body>
-</html>
+{% endblock %}

--- a/src/interfaces/templates/library/ignored_images.html
+++ b/src/interfaces/templates/library/ignored_images.html
@@ -1,14 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Ignored files</title>
-  <link rel="stylesheet" href="/static/css/brand.css">
+{% extends "settings/base.html" %}
+
+{% block title %}Ignored files{% endblock %}
+
+{% block extra_head %}
   <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { display: flex; flex-direction: column; font-family: sans-serif; min-height: 100vh; background: var(--color-bg-page); }
-    .main-content { flex: 1; padding: 2rem; max-width: 1200px; }
+    .main-content { padding: 2rem; max-width: 1200px; }
     .page-header { display: flex; align-items: baseline; gap: 1rem; margin-bottom: 0.5rem; }
     .page-title { font-size: 1.5rem; }
     .folder-path { font-family: monospace; color: #666; word-break: break-all; }
@@ -60,11 +56,9 @@
     .pagination { display: flex; gap: 1rem; align-items: center; margin-top: 1.5rem; color: #64748b; font-size: 0.9rem; }
     .empty-state { padding: 2rem; text-align: center; color: #94a3b8; }
   </style>
-</head>
-<body>
+{% endblock %}
 
-{% include "_top_nav.html" with active_section="library" %}
-
+{% block settings_content %}
 <div class="main-content">
   <div class="page-header">
     <h1 class="page-title">Ignored files</h1>
@@ -162,13 +156,13 @@
     <div class="empty-state">Nothing has been ignored in this folder.</div>
   {% endif %}
 </div>
+{% endblock %}
 
+{% block extra_scripts %}
 <script>
   document.querySelectorAll('time.local-time').forEach(function (el) {
     var d = new Date(el.dataset.utc);
     if (!isNaN(d)) el.textContent = d.toLocaleString();
   });
 </script>
-
-</body>
-</html>
+{% endblock %}

--- a/src/interfaces/templates/library/library.html
+++ b/src/interfaces/templates/library/library.html
@@ -1,16 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Image Library</title>
-  <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-  <link rel="stylesheet" href="/static/css/brand.css">
-  <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { display: flex; flex-direction: column; font-family: sans-serif; min-height: 100vh; background: var(--color-bg-page); }
+{% extends "settings/base.html" %}
 
-    .main-content { flex: 1; padding: 2rem; max-width: 1200px; }
+{% block title %}Image Library{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .main-content { padding: 2rem; max-width: 1200px; }
 
     .page-header {
       display: flex;
@@ -201,11 +195,9 @@
       min-height: 0;
     }
   </style>
-</head>
-<body>
+{% endblock %}
 
-{% include "_top_nav.html" with active_section="library" %}
-
+{% block settings_content %}
 <div class="main-content">
   <div class="page-header">
     <h1 class="page-title">Image Library</h1>
@@ -250,7 +242,9 @@
     <div id="browser-modal-content"></div>
   </div>
 </div>
+{% endblock %}
 
+{% block extra_scripts %}
 <script>
   function openBrowserModal(folderId, initialPath) {
     var url = '{% url "library-browse" %}';
@@ -291,6 +285,4 @@
       + String(d.getMinutes()).padStart(2, '0');
   });
 </script>
-
-</body>
-</html>
+{% endblock %}

--- a/src/interfaces/templates/settings/base.html
+++ b/src/interfaces/templates/settings/base.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}Settings{% endblock %}</title>
+  <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="/static/css/brand.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { display: flex; flex-direction: column; font-family: sans-serif; min-height: 100vh; background: var(--color-bg-page); }
+
+    /* Top nav sits above a sidebar-plus-content row that fills the rest of the
+       viewport. Future settings tabs slot into the sidebar without touching this. */
+    .settings-layout {
+      display: flex;
+      flex: 1;
+      min-height: 0;
+    }
+
+    .settings-sidebar {
+      flex-shrink: 0;
+      width: 220px;
+      padding: 1.5rem 0.75rem;
+      background: var(--color-bg-surface);
+      border-right: 1px solid var(--color-border);
+    }
+
+    .settings-sidebar__heading {
+      padding: 0 0.75rem;
+      margin-bottom: 0.75rem;
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #94a3b8;
+    }
+
+    .settings-nav { display: flex; flex-direction: column; gap: 0.15rem; }
+
+    .settings-nav__item {
+      display: block;
+      padding: 0.45rem 0.75rem;
+      border-radius: 6px;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--color-text-primary);
+      text-decoration: none;
+    }
+
+    .settings-nav__item:hover { background: var(--color-bg-page); }
+
+    .settings-nav__item--active {
+      background: var(--color-accent);
+      color: #fff;
+      font-weight: 600;
+    }
+
+    .settings-nav__item--active:hover { background: var(--color-accent); }
+
+    .settings-content { flex: 1; min-width: 0; overflow: auto; }
+  </style>
+  {% block extra_head %}{% endblock %}
+</head>
+<body>
+
+{% include "_top_nav.html" with active_section="settings" %}
+
+<div class="settings-layout">
+  <aside class="settings-sidebar">
+    {% include "settings/includes/sidebar.html" %}
+  </aside>
+  <main class="settings-content">
+    {% block settings_content %}{% endblock %}
+  </main>
+</div>
+
+{% block extra_scripts %}{% endblock %}
+
+</body>
+</html>

--- a/src/interfaces/templates/settings/includes/sidebar.html
+++ b/src/interfaces/templates/settings/includes/sidebar.html
@@ -6,4 +6,6 @@
 <nav class="settings-nav">
   <a href="{% url 'library-list' %}"
      class="settings-nav__item{% if active_tab == 'library' %} settings-nav__item--active{% endif %}">Library</a>
+  <a href="{% url 'camera-diagnostics' %}"
+     class="settings-nav__item{% if active_tab == 'camera-diagnostics' %} settings-nav__item--active{% endif %}">Camera Diagnostics</a>
 </nav>

--- a/src/interfaces/templates/settings/includes/sidebar.html
+++ b/src/interfaces/templates/settings/includes/sidebar.html
@@ -1,0 +1,9 @@
+{% comment %}
+  Settings sidebar. Each tab is one line here; `active_tab` (set by the view)
+  decides which one is highlighted. Add a new tab by adding another anchor.
+{% endcomment %}
+<div class="settings-sidebar__heading">Settings</div>
+<nav class="settings-nav">
+  <a href="{% url 'library-list' %}"
+     class="settings-nav__item{% if active_tab == 'library' %} settings-nav__item--active{% endif %}">Library</a>
+</nav>

--- a/tests/functional/test_camera_client_templates.py
+++ b/tests/functional/test_camera_client_templates.py
@@ -145,7 +145,7 @@ class TestCameraClientTemplates:
         card = _soup(client, "/recipes/").find("template", id="camera-unavailable-template")
 
         assert card.select_one("[data-unavailable-reason]") is not None
-        assert card.find("a", href="/camera/diagnostics/") is not None
+        assert card.find("a", href="/settings/camera-diagnostics/") is not None
 
     def test_only_the_standalone_templates_carry_a_card(self, client, settings):
         # The contract send_to_camera.js depends on, worth stating because

--- a/tests/functional/test_camera_diagnostics_view.py
+++ b/tests/functional/test_camera_diagnostics_view.py
@@ -3,30 +3,31 @@ from src.domain.camera import ptp_device
 
 class TestCameraDiagnostics:
     def test_renders_the_diagnostics_page(self, client):
-        response = client.get("/camera/diagnostics/")
+        response = client.get("/settings/camera-diagnostics/")
 
         assert response.status_code == 200
         content = response.content.decode()
         assert "Camera diagnostics" in content
 
     def test_exposes_the_fujifilm_vendor_id_to_the_probe_script(self, client):
-        response = client.get("/camera/diagnostics/")
+        response = client.get("/settings/camera-diagnostics/")
 
         content = response.content.decode()
         assert f"const FUJIFILM_VENDOR_ID = {ptp_device.FUJIFILM_VENDOR_ID};" in content
 
     def test_labels_the_vendor_id_in_hexadecimal_for_the_reader(self, client):
-        response = client.get("/camera/diagnostics/")
+        response = client.get("/settings/camera-diagnostics/")
 
         assert f"0x{ptp_device.FUJIFILM_VENDOR_ID:04X}" in response.content.decode()
 
-    def test_highlights_the_camera_section_in_the_navigation(self, client):
-        response = client.get("/camera/diagnostics/")
+    def test_highlights_the_camera_diagnostics_tab_in_the_sidebar(self, client):
+        response = client.get("/settings/camera-diagnostics/")
 
-        assert "top-nav__link--active" in response.content.decode()
+        content = response.content.decode()
+        assert 'settings-nav__item--active">Camera Diagnostics' in content
 
     def test_reports_every_probe_step_the_push_path_depends_on(self, client):
-        response = client.get("/camera/diagnostics/")
+        response = client.get("/settings/camera-diagnostics/")
 
         content = response.content.decode()
         for check_id in ("check-secure", "check-webusb", "check-open", "check-endpoints", "check-claim"):
@@ -38,12 +39,12 @@ class TestCameraDiagnosticsPTPSession:
         # The steps above it only prove the browser can reach the device. This
         # one proves the camera will hold a PTP conversation, which is what the
         # push path actually depends on.
-        response = client.get("/camera/diagnostics/")
+        response = client.get("/settings/camera-diagnostics/")
 
         assert "check-session" in response.content.decode()
 
     def test_loads_the_transport_as_a_module(self, client):
-        response = client.get("/camera/diagnostics/")
+        response = client.get("/settings/camera-diagnostics/")
 
         content = response.content.decode()
         assert '<script type="module">' in content
@@ -53,7 +54,7 @@ class TestCameraDiagnosticsPTPSession:
         # The page used to define findBulkInterface itself. Two versions of
         # endpoint discovery is the drift this port exists to avoid, so it now
         # imports the transport's.
-        content = client.get("/camera/diagnostics/").content.decode()
+        content = client.get("/settings/camera-diagnostics/").content.decode()
 
         assert "function findBulkInterface" not in content
         assert "_findBulkInterface" in content
@@ -61,7 +62,7 @@ class TestCameraDiagnosticsPTPSession:
     def test_points_at_the_client_config_endpoint(self, client):
         # The transport needs the timing settings, and fetching them on load
         # rather than on click keeps the user gesture intact for requestDevice.
-        content = client.get("/camera/diagnostics/").content.decode()
+        content = client.get("/settings/camera-diagnostics/").content.decode()
 
         assert "/camera/client-config.json" in content
 

--- a/tests/functional/test_library_ignored_images_view.py
+++ b/tests/functional/test_library_ignored_images_view.py
@@ -10,7 +10,7 @@ class TestLibraryFolderIgnoredImages:
         folder = LibraryFolderFactory(path="/photos")
         IgnoredImageFactory(folder=folder, filepath="/photos/other_brand.jpg")
 
-        response = client.get(f"/library/{folder.pk}/ignored/")
+        response = client.get(f"/settings/library/{folder.pk}/ignored/")
 
         assert response.status_code == 200
         content = response.content.decode()
@@ -21,7 +21,7 @@ class TestLibraryFolderIgnoredImages:
         folder = LibraryFolderFactory(path="/photos")
         IgnoredImageFactory(folder=folder, filepath="/photos/other_brand.jpg")
 
-        response = client.get(f"/library/{folder.pk}/ignored/")
+        response = client.get(f"/settings/library/{folder.pk}/ignored/")
 
         assert "None of them has been deleted or changed" in response.content.decode()
 
@@ -34,7 +34,7 @@ class TestLibraryFolderIgnoredImages:
             detail="OSError: disk went away",
         )
 
-        response = client.get(f"/library/{folder.pk}/ignored/")
+        response = client.get(f"/settings/library/{folder.pk}/ignored/")
 
         content = response.content.decode()
         assert "Failed with an error" in content
@@ -50,7 +50,7 @@ class TestLibraryFolderIgnoredImages:
         )
 
         response = client.get(
-            f"/library/{folder.pk}/ignored/?reason={models.IgnoredImage.REASON_ERROR}"
+            f"/settings/library/{folder.pk}/ignored/?reason={models.IgnoredImage.REASON_ERROR}"
         )
 
         content = response.content.decode()
@@ -67,7 +67,7 @@ class TestLibraryFolderIgnoredImages:
             reason=models.IgnoredImage.REASON_ERROR,
         )
 
-        response = client.get(f"/library/{folder.pk}/ignored/")
+        response = client.get(f"/settings/library/{folder.pk}/ignored/")
 
         content = response.content.decode()
         assert "Not a Fujifilm photo 2" in content
@@ -79,7 +79,7 @@ class TestLibraryFolderIgnoredImages:
         for index in range(5):
             IgnoredImageFactory(folder=folder, filepath=f"/photos/{index}.jpg")
 
-        response = client.get(f"/library/{folder.pk}/ignored/")
+        response = client.get(f"/settings/library/{folder.pk}/ignored/")
 
         content = response.content.decode()
         assert "Page 1 of 3" in content
@@ -89,12 +89,12 @@ class TestLibraryFolderIgnoredImages:
         folder = LibraryFolderFactory(path="/photos")
         IgnoredImageFactory(folder=LibraryFolderFactory(path="/scans"), filepath="/scans/x.jpg")
 
-        response = client.get(f"/library/{folder.pk}/ignored/")
+        response = client.get(f"/settings/library/{folder.pk}/ignored/")
 
         assert "Nothing has been ignored in this folder" in response.content.decode()
 
     def test_returns_404_for_unknown_folder_id(self, client):
-        assert client.get("/library/9999/ignored/").status_code == 404
+        assert client.get("/settings/library/9999/ignored/").status_code == 404
 
 
 @pytest.mark.django_db
@@ -103,7 +103,7 @@ class TestRetryingIgnoredImages:
         folder = LibraryFolderFactory(path="/photos")
         ignored = IgnoredImageFactory(folder=folder, filepath="/photos/other_brand.jpg")
 
-        response = client.post(f"/library/ignored/{ignored.pk}/retry/")
+        response = client.post(f"/settings/library/ignored/{ignored.pk}/retry/")
 
         assert response.status_code == 302
         assert models.IgnoredImage.objects.count() == 0
@@ -111,14 +111,14 @@ class TestRetryingIgnoredImages:
     def test_per_row_retry_returns_to_the_page_it_came_from(self, client):
         folder = LibraryFolderFactory(path="/photos")
         ignored = IgnoredImageFactory(folder=folder, filepath="/photos/other_brand.jpg")
-        came_from = f"/library/{folder.pk}/ignored/?page=2"
+        came_from = f"/settings/library/{folder.pk}/ignored/?page=2"
 
-        response = client.post(f"/library/ignored/{ignored.pk}/retry/", {"next": came_from})
+        response = client.post(f"/settings/library/ignored/{ignored.pk}/retry/", {"next": came_from})
 
         assert response["Location"] == came_from
 
     def test_per_row_retry_returns_404_for_unknown_id(self, client):
-        assert client.post("/library/ignored/9999/retry/").status_code == 404
+        assert client.post("/settings/library/ignored/9999/retry/").status_code == 404
 
     def test_retry_all_errors_leaves_the_other_reasons_alone(self, client):
         folder = LibraryFolderFactory(path="/photos")
@@ -130,7 +130,7 @@ class TestRetryingIgnoredImages:
         )
 
         client.post(
-            f"/library/{folder.pk}/ignored/retry/",
+            f"/settings/library/{folder.pk}/ignored/retry/",
             {"reason": models.IgnoredImage.REASON_ERROR},
         )
 
@@ -145,19 +145,19 @@ class TestRetryingIgnoredImages:
             reason=models.IgnoredImage.REASON_ERROR,
         )
 
-        response = client.post(f"/library/{folder.pk}/ignored/retry/")
+        response = client.post(f"/settings/library/{folder.pk}/ignored/retry/")
 
         assert response.status_code == 302
         assert models.IgnoredImage.objects.count() == 0
 
     def test_bulk_retry_returns_404_for_unknown_folder(self, client):
-        assert client.post("/library/9999/ignored/retry/").status_code == 404
+        assert client.post("/settings/library/9999/ignored/retry/").status_code == 404
 
     def test_offers_retry_all_errors_only_when_there_are_errors(self, client):
         folder = LibraryFolderFactory(path="/photos")
         IgnoredImageFactory(folder=folder, filepath="/photos/other_brand.jpg")
 
-        response = client.get(f"/library/{folder.pk}/ignored/")
+        response = client.get(f"/settings/library/{folder.pk}/ignored/")
 
         assert "Retry all" not in response.content.decode()
 
@@ -165,7 +165,7 @@ class TestRetryingIgnoredImages:
         folder = LibraryFolderFactory(path="/photos")
         IgnoredImageFactory(folder=folder, filepath="/photos/other_brand.jpg")
 
-        response = client.get(f"/library/{folder.pk}/ignored/")
+        response = client.get(f"/settings/library/{folder.pk}/ignored/")
 
         assert "Only changes anything once the file itself has changed" in response.content.decode()
 
@@ -177,6 +177,6 @@ class TestRetryingIgnoredImages:
             reason=models.IgnoredImage.REASON_ERROR,
         )
 
-        response = client.get(f"/library/{folder.pk}/ignored/")
+        response = client.get(f"/settings/library/{folder.pk}/ignored/")
 
         assert "Only changes anything once" not in response.content.decode()

--- a/tests/functional/test_library_sync_status_view.py
+++ b/tests/functional/test_library_sync_status_view.py
@@ -9,7 +9,7 @@ class TestLibraryFolderSyncStatus:
     def test_shows_not_synced_when_no_run_exists(self, client):
         folder = LibraryFolderFactory()
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         assert response.status_code == 200
         content = response.content.decode()
@@ -20,7 +20,7 @@ class TestLibraryFolderSyncStatus:
         folder = LibraryFolderFactory()
         SyncRunFactory(folder=folder, state=models.SyncRun.STATE_SCANNING)
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         content = response.content.decode()
         assert "Scanning" in content
@@ -32,7 +32,7 @@ class TestLibraryFolderSyncStatus:
         run.processed = 1
         run.save(update_fields=["processed"])
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         content = response.content.decode()
         assert "Processing 1/4" in content
@@ -50,7 +50,7 @@ class TestLibraryFolderSyncStatus:
         run.errors = 1
         run.save(update_fields=["processed", "skipped", "errors"])
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         content = response.content.decode()
         assert "Processing 4/10" in content
@@ -62,7 +62,7 @@ class TestLibraryFolderSyncStatus:
         run.skipped = 1
         run.save(update_fields=["processed", "skipped"])
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         content = response.content.decode()
         assert "Imported 2" in content
@@ -73,7 +73,7 @@ class TestLibraryFolderSyncStatus:
         folder = LibraryFolderFactory()
         SyncRunFactory(folder=folder, state=models.SyncRun.STATE_FAILED)
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         content = response.content.decode()
         assert "Sync failed" in content
@@ -87,7 +87,7 @@ class TestLibraryFolderSyncStatusRemovals:
         run = SyncRunFactory(folder=folder, state=models.SyncRun.STATE_COMPLETED, total=2)
         run.record_removal_results(missing_found=3, uncovered_found=0, removed=3, skipped_reason="")
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         assert "removed 3" in response.content.decode()
 
@@ -95,7 +95,7 @@ class TestLibraryFolderSyncStatusRemovals:
         folder = LibraryFolderFactory()
         SyncRunFactory(folder=folder, state=models.SyncRun.STATE_PRUNING, total=2)
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         content = response.content.decode()
         assert "Removing missing images" in content
@@ -111,7 +111,7 @@ class TestLibraryFolderSyncStatusRemovals:
             skipped_reason=models.SyncRun.SKIPPED_GUARD,
         )
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         content = response.content.decode()
         assert "Skipped removing 30 missing image" in content
@@ -125,7 +125,7 @@ class TestLibraryFolderSyncStatusRemovals:
             message="Folder does not exist",
         )
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         content = response.content.decode()
         assert "Folder not found on disk" in content
@@ -137,7 +137,7 @@ class TestLibraryFolderSyncStatusRemovals:
         run = SyncRunFactory(folder=folder, state=models.SyncRun.STATE_SCANNING)
         run.mark_failed(reason="", message="something else went wrong")
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         assert "Sync failed" in response.content.decode()
 
@@ -151,7 +151,7 @@ class TestLibraryFolderSyncStatusUncovered:
             missing_found=0, uncovered_found=2, removed=2, skipped_reason=""
         )
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         content = response.content.decode()
         assert "removed 2" in content
@@ -164,7 +164,7 @@ class TestLibraryFolderSyncStatusUncovered:
             missing_found=2, uncovered_found=0, removed=2, skipped_reason=""
         )
 
-        response = client.get(f"/library/{folder.pk}/sync-status/")
+        response = client.get(f"/settings/library/{folder.pk}/sync-status/")
 
         content = response.content.decode()
         assert "removed 2" in content

--- a/tests/functional/test_library_views.py
+++ b/tests/functional/test_library_views.py
@@ -13,14 +13,14 @@ TRIGGER = "src.interfaces.library.views.trigger_folder_sync_uc.trigger_folder_sy
 @pytest.mark.django_db
 class TestLibraryFolderList:
     def test_returns_200(self, client):
-        response = client.get("/library/")
+        response = client.get("/settings/library/")
         assert response.status_code == 200
 
     def test_lists_all_folders(self, client, tmp_path):
         folder_a = LibraryFolderFactory(path=str(tmp_path / "a"))
         folder_b = LibraryFolderFactory(path=str(tmp_path / "b"))
 
-        response = client.get("/library/")
+        response = client.get("/settings/library/")
 
         assert response.status_code == 200
         content = response.content.decode()
@@ -28,7 +28,7 @@ class TestLibraryFolderList:
         assert folder_b.path in content
 
     def test_shows_empty_state_when_no_folders(self, client):
-        response = client.get("/library/")
+        response = client.get("/settings/library/")
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
@@ -37,14 +37,14 @@ class TestLibraryFolderList:
     def test_folder_row_lazy_loads_its_sync_status(self, client, tmp_path):
         folder = LibraryFolderFactory(path=str(tmp_path))
 
-        response = client.get("/library/")
+        response = client.get("/settings/library/")
 
         content = response.content.decode()
-        assert f"/library/{folder.pk}/sync-status/" in content
+        assert f"/settings/library/{folder.pk}/sync-status/" in content
         assert 'hx-trigger="load"' in content
 
     def test_shows_library_nav_link_as_active(self, client):
-        response = client.get("/library/")
+        response = client.get("/settings/library/")
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
@@ -59,10 +59,10 @@ class TestLibraryFolderAdd:
         new_dir.mkdir()
 
         with patch(TRIGGER):
-            response = client.post("/library/new/",{"path": str(new_dir)})
+            response = client.post("/settings/library/new/",{"path": str(new_dir)})
 
         assert response.status_code == 302
-        assert response["Location"] == "/library/"
+        assert response["Location"] == "/settings/library/"
         assert models.LibraryFolder.objects.filter(path=str(new_dir)).exists()
 
     def test_triggers_sync_for_the_new_folder(self, client, tmp_path):
@@ -70,7 +70,7 @@ class TestLibraryFolderAdd:
         new_dir.mkdir()
 
         with patch(TRIGGER) as mock_trigger:
-            client.post("/library/new/",{"path": str(new_dir)})
+            client.post("/settings/library/new/",{"path": str(new_dir)})
 
         folder = models.LibraryFolder.objects.get(path=str(new_dir))
         mock_trigger.assert_called_once_with(folder_id=folder.pk)
@@ -80,7 +80,7 @@ class TestLibraryFolderAdd:
         new_dir.mkdir()
 
         with patch(TRIGGER, side_effect=CeleryWorkerUnavailable()):
-            response = client.post("/library/new/",{"path": str(new_dir)})
+            response = client.post("/settings/library/new/",{"path": str(new_dir)})
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
@@ -91,7 +91,7 @@ class TestLibraryFolderAdd:
     def test_returns_error_for_nonexistent_path(self, client, tmp_path):
         missing = str(tmp_path / "does_not_exist")
 
-        response = client.post("/library/new/",{"path": missing})
+        response = client.post("/settings/library/new/",{"path": missing})
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
@@ -102,14 +102,14 @@ class TestLibraryFolderAdd:
         existing_dir.mkdir()
         LibraryFolderFactory(path=str(existing_dir))
 
-        response = client.post("/library/new/",{"path": str(existing_dir)})
+        response = client.post("/settings/library/new/",{"path": str(existing_dir)})
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
         assert soup.find(class_="error-banner") is not None
 
     def test_returns_400_when_path_is_missing(self, client):
-        response = client.post("/library/new/",{})
+        response = client.post("/settings/library/new/",{})
         assert response.status_code == 400
 
 
@@ -118,21 +118,21 @@ class TestLibraryFolderRemove:
     def test_removes_folder_and_redirects_to_list(self, client):
         folder = LibraryFolderFactory()
 
-        response = client.post(f"/library/{folder.pk}/delete/")
+        response = client.post(f"/settings/library/{folder.pk}/delete/")
 
         assert response.status_code == 302
-        assert response["Location"] == "/library/"
+        assert response["Location"] == "/settings/library/"
         assert not models.LibraryFolder.objects.filter(pk=folder.pk).exists()
 
     def test_returns_404_for_unknown_folder_id(self, client):
-        response = client.post("/library/99999/delete/")
+        response = client.post("/settings/library/99999/delete/")
         assert response.status_code == 404
 
     def test_keeps_the_images_by_default(self, client):
         folder = LibraryFolderFactory(path="/photos")
         image = ImageFactory(filepath="/photos/DSCF0001.JPG")
 
-        client.post(f"/library/{folder.pk}/delete/")
+        client.post(f"/settings/library/{folder.pk}/delete/")
 
         assert models.Image.objects.filter(pk=image.pk).exists()
 
@@ -140,7 +140,7 @@ class TestLibraryFolderRemove:
         folder = LibraryFolderFactory(path="/photos")
         image = ImageFactory(filepath="/photos/DSCF0001.JPG")
 
-        client.post(f"/library/{folder.pk}/delete/", {"delete_images": "on"})
+        client.post(f"/settings/library/{folder.pk}/delete/", {"delete_images": "on"})
 
         assert not models.Image.objects.filter(pk=image.pk).exists()
 
@@ -152,7 +152,7 @@ class TestLibraryFolderRemoveConfirm:
         ImageFactory(filepath="/photos/DSCF0001.JPG")
         ImageFactory(filepath="/photos/2024/DSCF0002.JPG")
 
-        response = client.get(f"/library/{folder.pk}/confirm-delete/")
+        response = client.get(f"/settings/library/{folder.pk}/confirm-delete/")
 
         content = response.content.decode()
         assert response.status_code == 200
@@ -163,14 +163,14 @@ class TestLibraryFolderRemoveConfirm:
         folder = LibraryFolderFactory(path="/photos")
         ImageFactory(filepath="/photos/DSCF0001.JPG")
 
-        response = client.get(f"/library/{folder.pk}/confirm-delete/")
+        response = client.get(f"/settings/library/{folder.pk}/confirm-delete/")
 
         assert "Your photo files are never deleted" in response.content.decode()
 
     def test_offers_only_the_folder_when_nothing_would_leave_the_gallery(self, client):
         folder = LibraryFolderFactory(path="/photos")
 
-        response = client.get(f"/library/{folder.pk}/confirm-delete/")
+        response = client.get(f"/settings/library/{folder.pk}/confirm-delete/")
 
         content = response.content.decode()
         assert "No image in the gallery comes only from this folder" in content
@@ -181,12 +181,12 @@ class TestLibraryFolderRemoveConfirm:
         inner = LibraryFolderFactory(path="/photos/2024")
         ImageFactory(filepath="/photos/2024/DSCF0001.JPG")
 
-        response = client.get(f"/library/{inner.pk}/confirm-delete/")
+        response = client.get(f"/settings/library/{inner.pk}/confirm-delete/")
 
         assert "No image in the gallery comes only from this folder" in response.content.decode()
 
     def test_returns_404_for_unknown_folder_id(self, client):
-        assert client.get("/library/99999/confirm-delete/").status_code == 404
+        assert client.get("/settings/library/99999/confirm-delete/").status_code == 404
 
 
 @pytest.mark.django_db
@@ -199,10 +199,10 @@ class TestLibraryFolderPathUpdate:
         folder = LibraryFolderFactory(path=str(old_dir))
 
         with patch(TRIGGER):
-            response = client.post(f"/library/{folder.pk}/edit/",{"path": str(new_dir)})
+            response = client.post(f"/settings/library/{folder.pk}/edit/",{"path": str(new_dir)})
 
         assert response.status_code == 302
-        assert response["Location"] == "/library/"
+        assert response["Location"] == "/settings/library/"
         folder.refresh_from_db()
         assert folder.path == str(new_dir)
 
@@ -214,7 +214,7 @@ class TestLibraryFolderPathUpdate:
         folder = LibraryFolderFactory(path=str(old_dir))
 
         with patch(TRIGGER) as mock_trigger:
-            client.post(f"/library/{folder.pk}/edit/",{"path": str(new_dir)})
+            client.post(f"/settings/library/{folder.pk}/edit/",{"path": str(new_dir)})
 
         mock_trigger.assert_called_once_with(folder_id=folder.pk)
 
@@ -222,7 +222,7 @@ class TestLibraryFolderPathUpdate:
         new_dir = tmp_path / "new"
         new_dir.mkdir()
 
-        response = client.post("/library/99999/edit/",{"path": str(new_dir)})
+        response = client.post("/settings/library/99999/edit/",{"path": str(new_dir)})
 
         assert response.status_code == 404
 
@@ -230,7 +230,7 @@ class TestLibraryFolderPathUpdate:
         folder = LibraryFolderFactory(path=str(tmp_path))
         missing = str(tmp_path / "does_not_exist")
 
-        response = client.post(f"/library/{folder.pk}/edit/",{"path": missing})
+        response = client.post(f"/settings/library/{folder.pk}/edit/",{"path": missing})
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
@@ -244,7 +244,7 @@ class TestLibraryFolderPathUpdate:
         LibraryFolderFactory(path=str(dir_a))
         folder_b = LibraryFolderFactory(path=str(dir_b))
 
-        response = client.post(f"/library/{folder_b.pk}/edit/",{"path": str(dir_a)})
+        response = client.post(f"/settings/library/{folder_b.pk}/edit/",{"path": str(dir_a)})
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
@@ -253,7 +253,7 @@ class TestLibraryFolderPathUpdate:
     def test_returns_400_when_path_is_missing(self, client):
         folder = LibraryFolderFactory()
 
-        response = client.post(f"/library/{folder.pk}/edit/",{})
+        response = client.post(f"/settings/library/{folder.pk}/edit/",{})
 
         assert response.status_code == 400
 
@@ -261,14 +261,14 @@ class TestLibraryFolderPathUpdate:
 @pytest.mark.django_db
 class TestFilesystemBrowser:
     def test_returns_200_with_default_path(self, client):
-        response = client.get("/library/browse/partial/")
+        response = client.get("/settings/library/browse/partial/")
         assert response.status_code == 200
 
     def test_lists_immediate_subdirectories(self, client, tmp_path):
         (tmp_path / "alpha").mkdir()
         (tmp_path / "beta").mkdir()
 
-        response = client.get(f"/library/browse/partial/?path={tmp_path}")
+        response = client.get(f"/settings/library/browse/partial/?path={tmp_path}")
 
         assert response.status_code == 200
         content = response.content.decode()
@@ -276,14 +276,14 @@ class TestFilesystemBrowser:
         assert "beta" in content
 
     def test_shows_back_link_when_not_at_root(self, client, tmp_path):
-        response = client.get(f"/library/browse/partial/?path={tmp_path}")
+        response = client.get(f"/settings/library/browse/partial/?path={tmp_path}")
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
         assert soup.find(class_="browser-back-link") is not None
 
     def test_no_back_link_at_filesystem_root(self, client):
-        response = client.get("/library/browse/partial/?path=/")
+        response = client.get("/settings/library/browse/partial/?path=/")
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
@@ -292,30 +292,30 @@ class TestFilesystemBrowser:
     def test_returns_404_for_nonexistent_path(self, client, tmp_path):
         missing = str(tmp_path / "does_not_exist")
 
-        response = client.get(f"/library/browse/partial/?path={missing}")
+        response = client.get(f"/settings/library/browse/partial/?path={missing}")
 
         assert response.status_code == 404
 
     def test_select_form_posts_to_add_url_without_folder_id(self, client, tmp_path):
-        response = client.get(f"/library/browse/partial/?path={tmp_path}")
+        response = client.get(f"/settings/library/browse/partial/?path={tmp_path}")
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
         form = soup.find("form")
-        assert form["action"] == "/library/new/"
+        assert form["action"] == "/settings/library/new/"
 
     def test_select_form_posts_to_update_url_with_folder_id(self, client, tmp_path):
         folder = LibraryFolderFactory(path=str(tmp_path))
 
-        response = client.get(f"/library/browse/partial/?path={tmp_path}&folder_id={folder.pk}")
+        response = client.get(f"/settings/library/browse/partial/?path={tmp_path}&folder_id={folder.pk}")
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
         form = soup.find("form")
-        assert form["action"] == f"/library/{folder.pk}/edit/"
+        assert form["action"] == f"/settings/library/{folder.pk}/edit/"
 
     def test_returns_400_for_non_integer_folder_id(self, client, tmp_path):
-        response = client.get(f"/library/browse/partial/?path={tmp_path}&folder_id=not-an-int")
+        response = client.get(f"/settings/library/browse/partial/?path={tmp_path}&folder_id=not-an-int")
 
         assert response.status_code == 400
 
@@ -327,19 +327,19 @@ class TestLibraryPageIgnoredCount:
         IgnoredImageFactory(folder=folder, filepath="/photos/a.jpg")
         IgnoredImageFactory(folder=folder, filepath="/photos/b.jpg")
 
-        response = client.get("/library/")
+        response = client.get("/settings/library/")
 
         content = response.content.decode()
         assert "2 ignored" in content
-        assert f"/library/{folder.pk}/ignored/" in content
+        assert f"/settings/library/{folder.pk}/ignored/" in content
 
     def test_shows_none_without_a_link_when_nothing_is_ignored(self, client):
         folder = LibraryFolderFactory(path="/photos")
 
-        response = client.get("/library/")
+        response = client.get("/settings/library/")
 
         content = response.content.decode()
-        assert f"/library/{folder.pk}/ignored/" not in content
+        assert f"/settings/library/{folder.pk}/ignored/" not in content
         assert "None" in content
 
     def test_counts_each_folder_separately(self, client):
@@ -349,7 +349,7 @@ class TestLibraryPageIgnoredCount:
         IgnoredImageFactory(folder=second, filepath="/scans/a.jpg")
         IgnoredImageFactory(folder=second, filepath="/scans/b.jpg")
 
-        content = client.get("/library/").content.decode()
+        content = client.get("/settings/library/").content.decode()
 
         assert "1 ignored" in content
         assert "2 ignored" in content

--- a/tests/functional/test_library_views.py
+++ b/tests/functional/test_library_views.py
@@ -43,13 +43,13 @@ class TestLibraryFolderList:
         assert f"/settings/library/{folder.pk}/sync-status/" in content
         assert 'hx-trigger="load"' in content
 
-    def test_shows_library_nav_link_as_active(self, client):
+    def test_shows_library_sidebar_item_as_active(self, client):
         response = client.get("/settings/library/")
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.content, "html.parser")
-        active_links = soup.find_all(class_="top-nav__link--active")
-        assert any("Library" in link.text for link in active_links)
+        active_items = soup.find_all(class_="settings-nav__item--active")
+        assert any("Library" in item.text for item in active_items)
 
 
 @pytest.mark.django_db

--- a/tests/functional/test_settings_views.py
+++ b/tests/functional/test_settings_views.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.mark.django_db
+class TestSettingsRedirect:
+    def test_settings_redirects_to_library(self, client):
+        response = client.get("/settings/")
+
+        assert response.status_code == 302
+        assert response["Location"] == "/settings/library/"


### PR DESCRIPTION
## Move Library (and Camera Diagnostics) under a new Settings section

Library is now the first subpage of a first-class **Settings** section reached
through a left sidebar, replacing its old top-nav link. This sets up a reusable
shell (top nav → sidebar → content) that future settings tabs plug into without
further restructuring. As part of it, the dead top-nav "Camera" link (it was
never wired to a page) is removed and the existing Camera Diagnostics page
becomes the second sidebar tab.

Interface-layer only: no data, domain, or application changes.

### What changed
- New `settings` interface app: `/settings/` redirects to the first tab, and the
  library URLs are mounted under `/settings/library/`.
- New `settings/base.html` shell plus a sidebar include whose active tab is
  driven by an `active_tab` context value; the Library and Camera Diagnostics
  pages extend it.
- Top nav is now **Recipes | Images | Settings**.
- Camera Diagnostics moves to `/settings/camera-diagnostics/`.
