### PR TITLE
Compact image design

### DIFF
--- a/src/interfaces/static/js/compact-gallery.js
+++ b/src/interfaces/static/js/compact-gallery.js
@@ -1,0 +1,186 @@
+// Compact ("justified") gallery layout for the Images page.
+//
+// Adds a second, opt-in layout to the gallery alongside the default 3-column
+// grid. In compact mode, thumbnails are packed into rows that are each scaled
+// to a single height and fill the full content width — so mixed aspect ratios
+// tile edge-to-edge with no cropping (Google-Photos style). Aspect ratios are
+// measured from the loaded thumbnails; nothing is stored server-side.
+//
+// The view mode (grid|compact) and label mode (hover|always) are persisted in
+// localStorage and applied client-side with no page reload. The same
+// `.image-card` DOM is used in both modes, so multi-select, the detail overlay
+// and rating keep working unchanged.
+
+(function () {
+  var VIEW_KEY = 'galleryViewMode';
+  var LABEL_KEY = 'galleryLabelMode';
+  var GAP = 4; // must match `#gallery-results.layout-compact { gap }` in gallery.html
+  var FALLBACK_RATIO = 1.5; // used until a thumbnail has loaded and can be measured
+
+  var container = document.getElementById('gallery-results');
+  if (!container) return;
+
+  function readView() {
+    return localStorage.getItem(VIEW_KEY) === 'compact' ? 'compact' : 'grid';
+  }
+
+  function readLabels() {
+    return localStorage.getItem(LABEL_KEY) === 'always' ? 'always' : 'hover';
+  }
+
+  // ── Layout engine ──────────────────────────────────────────────────────
+
+  function targetRowHeight(width) {
+    return width < 700 ? 150 : 200;
+  }
+
+  function ratioOf(card) {
+    var img = card.querySelector('.image-thumbnail');
+    if (img && img.naturalWidth > 0 && img.naturalHeight > 0) {
+      return img.naturalWidth / img.naturalHeight;
+    }
+    return FALLBACK_RATIO;
+  }
+
+  // Assign each row's cards an integer width/height so the row fills the
+  // container exactly. Any rounding remainder is absorbed by the last card, so
+  // the row sum plus its gaps equals the container width and the next card
+  // wraps where intended.
+  function sizeRow(cards, ratios, height, containerWidth) {
+    var gaps = (cards.length - 1) * GAP;
+    var used = 0;
+    for (var i = 0; i < cards.length; i++) {
+      var isLast = i === cards.length - 1;
+      var w = isLast ? (containerWidth - gaps - used) : Math.floor(ratios[i] * height);
+      used += w;
+      cards[i].style.width = w + 'px';
+      cards[i].style.height = Math.round(height) + 'px';
+    }
+  }
+
+  function justify() {
+    if (!container.classList.contains('layout-compact')) return;
+    var containerWidth = container.clientWidth;
+    if (containerWidth <= 0) return;
+
+    var cards = Array.prototype.slice.call(container.querySelectorAll('.image-card'));
+    if (cards.length === 0) return;
+
+    var target = targetRowHeight(containerWidth);
+    var rowCards = [];
+    var rowRatios = [];
+    var ratioSum = 0;
+
+    for (var i = 0; i < cards.length; i++) {
+      var ratio = ratioOf(cards[i]);
+      rowCards.push(cards[i]);
+      rowRatios.push(ratio);
+      ratioSum += ratio;
+
+      var gaps = (rowCards.length - 1) * GAP;
+      if (ratioSum * target + gaps >= containerWidth) {
+        var height = (containerWidth - gaps) / ratioSum;
+        sizeRow(rowCards, rowRatios, height, containerWidth);
+        rowCards = [];
+        rowRatios = [];
+        ratioSum = 0;
+      }
+    }
+
+    // Trailing partial row: keep the target height (left-aligned), unless it is
+    // wide enough to warrant scaling down to fit.
+    if (rowCards.length > 0) {
+      var lastGaps = (rowCards.length - 1) * GAP;
+      var natural = ratioSum * target + lastGaps;
+      var h = natural > containerWidth ? (containerWidth - lastGaps) / ratioSum : target;
+      sizeRow(rowCards, rowRatios, h, containerWidth);
+    }
+  }
+
+  function clearSizes() {
+    var cards = container.querySelectorAll('.image-card');
+    for (var i = 0; i < cards.length; i++) {
+      cards[i].style.width = '';
+      cards[i].style.height = '';
+    }
+  }
+
+  // Coalesce re-layout requests into one per animation frame.
+  var scheduled = false;
+  function scheduleJustify() {
+    if (scheduled) return;
+    scheduled = true;
+    window.requestAnimationFrame(function () {
+      scheduled = false;
+      justify();
+    });
+  }
+
+  // ── View / label mode ──────────────────────────────────────────────────
+
+  function setActive(buttons, attr, value) {
+    for (var i = 0; i < buttons.length; i++) {
+      var isActive = buttons[i].getAttribute(attr) === value;
+      buttons[i].classList.toggle('segmented-toggle__option--active', isActive);
+    }
+  }
+
+  function applyView(mode) {
+    container.classList.remove('layout-grid', 'layout-compact');
+    container.classList.add('layout-' + mode);
+    setActive(viewButtons, 'data-view-mode', mode);
+    if (labelControl) labelControl.hidden = mode !== 'compact';
+    if (mode === 'compact') {
+      justify(); // immediate; load/resize/swap refine it via scheduleJustify
+    } else {
+      clearSizes();
+    }
+    localStorage.setItem(VIEW_KEY, mode);
+  }
+
+  function applyLabels(mode) {
+    container.classList.remove('labels-hover', 'labels-always');
+    container.classList.add('labels-' + mode);
+    setActive(labelButtons, 'data-label-mode', mode);
+    localStorage.setItem(LABEL_KEY, mode);
+  }
+
+  // ── Wiring ─────────────────────────────────────────────────────────────
+
+  var viewSwitcher = document.getElementById('view-switcher');
+  var labelControl = document.getElementById('label-mode');
+  var viewButtons = viewSwitcher ? viewSwitcher.querySelectorAll('[data-view-mode]') : [];
+  var labelButtons = labelControl ? labelControl.querySelectorAll('[data-label-mode]') : [];
+
+  if (viewSwitcher) {
+    viewSwitcher.addEventListener('click', function (evt) {
+      var btn = evt.target.closest('[data-view-mode]');
+      if (btn) applyView(btn.getAttribute('data-view-mode'));
+    });
+  }
+
+  if (labelControl) {
+    labelControl.addEventListener('click', function (evt) {
+      var btn = evt.target.closest('[data-label-mode]');
+      if (btn) applyLabels(btn.getAttribute('data-label-mode'));
+    });
+  }
+
+  // Re-justify as thumbnails finish loading (load does not bubble — capture it),
+  // on resize, and after HTMX swaps replace or append cards.
+  container.addEventListener('load', function (evt) {
+    if (evt.target && evt.target.classList.contains('image-thumbnail')) scheduleJustify();
+  }, true);
+
+  window.addEventListener('resize', scheduleJustify);
+
+  document.body.addEventListener('htmx:afterSwap', function () {
+    if (container.classList.contains('layout-compact')) scheduleJustify();
+  });
+
+  // Apply the stored preferences. The inline script in gallery.html already set
+  // the container classes to avoid a flash; this syncs the control states and
+  // runs the initial justification.
+  applyView(readView());
+  applyLabels(readLabels());
+}());

--- a/src/interfaces/static/js/compact-gallery.js
+++ b/src/interfaces/static/js/compact-gallery.js
@@ -14,8 +14,12 @@
 (function () {
   var VIEW_KEY = 'galleryViewMode';
   var LABEL_KEY = 'galleryLabelMode';
+  var ROW_HEIGHT_KEY = 'galleryRowHeight';
   var GAP = 4; // must match `#gallery-results.layout-compact { gap }` in gallery.html
   var FALLBACK_RATIO = 1.5; // used until a thumbnail has loaded and can be measured
+  var DEFAULT_ROW_HEIGHT = 280; // near the grid layout's fixed 300px, so switching feels size-consistent
+  var MIN_ROW_HEIGHT = 120; // keep in sync with the size-slider min in gallery_actions.html
+  var MAX_ROW_HEIGHT = 500; // keep in sync with the size-slider max in gallery_actions.html
 
   var container = document.getElementById('gallery-results');
   if (!container) return;
@@ -28,11 +32,16 @@
     return localStorage.getItem(LABEL_KEY) === 'always' ? 'always' : 'hover';
   }
 
-  // ── Layout engine ──────────────────────────────────────────────────────
-
-  function targetRowHeight(width) {
-    return width < 700 ? 150 : 200;
+  // Preferred row height (the target the justified rows are solved toward),
+  // set by the size slider. Actual per-row heights come out at or below it so
+  // each row fills the width exactly.
+  function readRowHeight() {
+    var stored = parseInt(localStorage.getItem(ROW_HEIGHT_KEY), 10);
+    if (isNaN(stored)) return DEFAULT_ROW_HEIGHT;
+    return Math.max(MIN_ROW_HEIGHT, Math.min(MAX_ROW_HEIGHT, stored));
   }
+
+  // ── Layout engine ──────────────────────────────────────────────────────
 
   function ratioOf(card) {
     var img = card.querySelector('.image-thumbnail');
@@ -66,7 +75,7 @@
     var cards = Array.prototype.slice.call(container.querySelectorAll('.image-card'));
     if (cards.length === 0) return;
 
-    var target = targetRowHeight(containerWidth);
+    var target = readRowHeight();
     var rowCards = [];
     var rowRatios = [];
     var ratioSum = 0;
@@ -130,6 +139,7 @@
     container.classList.add('layout-' + mode);
     setActive(viewButtons, 'data-view-mode', mode);
     if (labelControl) labelControl.hidden = mode !== 'compact';
+    if (sizeControl) sizeControl.hidden = mode !== 'compact';
     if (mode === 'compact') {
       justify(); // immediate; load/resize/swap refine it via scheduleJustify
     } else {
@@ -149,6 +159,8 @@
 
   var viewSwitcher = document.getElementById('view-switcher');
   var labelControl = document.getElementById('label-mode');
+  var sizeControl = document.getElementById('size-control');
+  var sizeSlider = document.getElementById('size-slider');
   var viewButtons = viewSwitcher ? viewSwitcher.querySelectorAll('[data-view-mode]') : [];
   var labelButtons = labelControl ? labelControl.querySelectorAll('[data-label-mode]') : [];
 
@@ -163,6 +175,14 @@
     labelControl.addEventListener('click', function (evt) {
       var btn = evt.target.closest('[data-label-mode]');
       if (btn) applyLabels(btn.getAttribute('data-label-mode'));
+    });
+  }
+
+  if (sizeSlider) {
+    sizeSlider.value = readRowHeight();
+    sizeSlider.addEventListener('input', function () {
+      localStorage.setItem(ROW_HEIGHT_KEY, sizeSlider.value);
+      scheduleJustify();
     });
   }
 

--- a/src/interfaces/templates/_top_nav.html
+++ b/src/interfaces/templates/_top_nav.html
@@ -47,6 +47,17 @@
     border-bottom: 2px solid var(--color-accent);
     border-radius: 0;
   }
+
+  /* Right-aligned slot where a page can render its own action buttons/toolbar
+     into the otherwise-empty header. The markup itself lives in the page's own
+     templates (passed via `nav_actions_template`); the nav only provides the
+     placement. */
+  .top-nav__actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
 </style>
 
 <nav class="top-nav">
@@ -56,4 +67,9 @@
   <a href="{% url 'recipes-explorer' %}" class="top-nav__link{% if active_section == 'recipes' %} top-nav__link--active{% endif %}">Recipes</a>
   <a href="{% url 'gallery' %}" class="top-nav__link{% if active_section == 'images' %} top-nav__link--active{% endif %}">Images</a>
   <a href="{% url 'settings' %}" class="top-nav__link{% if active_section == 'settings' %} top-nav__link--active{% endif %}">Settings</a>
+  {% if nav_actions_template %}
+  <div class="top-nav__actions">
+    {% include nav_actions_template %}
+  </div>
+  {% endif %}
 </nav>

--- a/src/interfaces/templates/images/_gallery_results.html
+++ b/src/interfaces/templates/images/_gallery_results.html
@@ -12,6 +12,11 @@
        hx-push-url="{% url 'image-detail' image.id %}"
        hx-include="#filter-form">
       <img class="image-thumbnail" src="{% url 'image-file' image.id %}?width=600" alt="{{ image.filename }}" loading="lazy">
+      {# Caption shown only in the compact layout (CSS-gated); grid mode uses the meta below. #}
+      <div class="image-overlay">
+        <span class="image-overlay-name">{% if image.fujifilm_recipe and image.fujifilm_recipe.name %}{{ image.fujifilm_recipe.name }}{% elif image.fujifilm_recipe and image.fujifilm_recipe.film_simulation %}{{ image.fujifilm_recipe.film_simulation }}{% else %}—{% endif %}</span>
+        {% if image.rating %}<span class="image-overlay-rating">{{ image.rating|stars }}</span>{% endif %}
+      </div>
     </a>
     <span class="image-recipe">{% if image.fujifilm_recipe and image.fujifilm_recipe.name %}{{ image.fujifilm_recipe.name }}{% elif image.fujifilm_recipe and image.fujifilm_recipe.film_simulation %}{{ image.fujifilm_recipe.film_simulation }}{% else %}—{% endif %}</span>
     <div class="image-meta-row">

--- a/src/interfaces/templates/images/gallery.html
+++ b/src/interfaces/templates/images/gallery.html
@@ -6,6 +6,7 @@
   <title>Image Gallery</title>
   <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
   <script src="/static/js/multi-select.js"></script>
+  <script src="/static/js/compact-gallery.js" defer></script>
   <link href="https://cdn.jsdelivr.net/npm/tom-select@2/dist/css/tom-select.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/tom-select@2/dist/js/tom-select.complete.min.js"></script>
   <link rel="stylesheet" href="/static/css/brand.css">
@@ -188,10 +189,20 @@
       left: calc(100% - 0.975rem);
     }
 
-    #gallery-results {
+    #gallery-results.layout-grid {
       display: grid;
       grid-template-columns: repeat(3, 1fr);
       gap: 1rem;
+    }
+
+    /* Compact ("justified") layout: rows are packed and sized by compact-gallery.js;
+       each row fills the content width at a shared height, so mixed aspect ratios
+       tile edge-to-edge with no cropping. */
+    #gallery-results.layout-compact {
+      display: flex;
+      flex-wrap: wrap;
+      align-content: flex-start;
+      gap: 4px;
     }
 
     .infinite-scroll-sentinel {
@@ -216,6 +227,103 @@
       border-radius: 4px;
       margin-bottom: 0.5rem;
       background: #f0f0f0;
+    }
+
+    /* ── Compact layout overrides ─────────────────────────────────────── */
+    #gallery-results.layout-compact .image-card {
+      flex: 0 0 auto; /* honor the exact width/height compact-gallery.js assigns */
+      border: none;
+      border-radius: 2px;
+      padding: 0;
+      background: none;
+      overflow: hidden;
+      /* width/height are assigned inline by compact-gallery.js */
+    }
+
+    #gallery-results.layout-compact .detail-link {
+      display: block;
+      position: relative;
+      height: 100%;
+    }
+
+    #gallery-results.layout-compact .image-thumbnail {
+      width: 100%;
+      height: 100%;
+      object-fit: cover; /* box matches the image's true aspect ratio, so nothing is cropped */
+      margin-bottom: 0;
+      border-radius: 0;
+    }
+
+    #gallery-results.layout-compact .image-recipe,
+    #gallery-results.layout-compact .image-meta-row,
+    #gallery-results.layout-compact .recipe-labels {
+      display: none;
+    }
+
+    #gallery-results.layout-compact .no-results {
+      flex: 1 1 100%;
+    }
+
+    /* Recipe-name overlay: rendered in every card, shown only in compact mode. */
+    .image-overlay {
+      display: none;
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      padding: 14px 8px 6px;
+      align-items: flex-end;
+      justify-content: space-between;
+      gap: 6px;
+      background: linear-gradient(to top, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0));
+      pointer-events: none;
+    }
+
+    .image-overlay-name {
+      color: #fff;
+      font-size: 0.75rem;
+      font-weight: 600;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+    }
+
+    .image-overlay-rating {
+      flex-shrink: 0;
+      font-size: 0.75rem;
+      color: var(--color-accent);
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    }
+
+    /* Label-mode: always-on vs reveal-on-hover (toggled by the header control). */
+    #gallery-results.layout-compact.labels-always .image-overlay {
+      display: flex;
+    }
+
+    #gallery-results.layout-compact.labels-hover .image-card:hover .image-overlay {
+      display: flex;
+    }
+
+    /* ── Header view controls (rendered into the top-nav actions slot) ──── */
+    .view-controls {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+    }
+
+    .label-mode {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+    }
+
+    .label-mode[hidden] {
+      display: none;
+    }
+
+    .view-switcher .segmented-toggle__option {
+      gap: 6px;
     }
 
     .image-recipe {
@@ -529,9 +637,21 @@
 
 <main class="main">
   <div class="gallery-scroll">
-    <div id="gallery-results">
+    <div id="gallery-results" class="layout-grid labels-hover">
       {% include "images/_gallery_results.html" %}
     </div>
+    <script>
+      // Apply the stored view/label preference synchronously to avoid a flash of
+      // the grid layout for users who last chose compact. The full engine
+      // (justified sizing, toggles, re-layout) lives in compact-gallery.js.
+      (function () {
+        var el = document.getElementById('gallery-results');
+        var view = localStorage.getItem('galleryViewMode') === 'compact' ? 'compact' : 'grid';
+        var labels = localStorage.getItem('galleryLabelMode') === 'always' ? 'always' : 'hover';
+        el.classList.remove('layout-grid', 'layout-compact', 'labels-hover', 'labels-always');
+        el.classList.add('layout-' + view, 'labels-' + labels);
+      }());
+    </script>
     <div id="load-more-sentinel">
       {% if page_obj.has_next %}
       <div class="infinite-scroll-sentinel"

--- a/src/interfaces/templates/images/gallery.html
+++ b/src/interfaces/templates/images/gallery.html
@@ -322,6 +322,22 @@
       display: none;
     }
 
+    .size-control {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .size-control[hidden] {
+      display: none;
+    }
+
+    .size-slider {
+      width: 110px;
+      accent-color: var(--color-accent);
+      cursor: pointer;
+    }
+
     .view-switcher .segmented-toggle__option {
       gap: 6px;
     }

--- a/src/interfaces/templates/images/gallery.html
+++ b/src/interfaces/templates/images/gallery.html
@@ -140,23 +140,10 @@
       overflow: hidden;
     }
 
-    .gallery-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 2rem 2rem 1rem;
-      flex-shrink: 0;
-    }
-
     .gallery-scroll {
       flex: 1;
       overflow-y: auto;
-      padding: 0 2rem 2rem;
-    }
-
-    .gallery-header h1 {
-      font-size: 1.5rem;
-      color: #222;
+      padding: 1.5rem 2rem 2rem;
     }
 
     .rating-toggle {
@@ -305,14 +292,6 @@
       grid-column: 1 / -1;
       color: #888;
       font-style: italic;
-    }
-
-    .gallery-header {
-      display: flex;
-      align-items: center;
-      padding: 1rem 2rem;
-      flex-shrink: 0;
-      min-height: 4rem;
     }
 
     /* ── Multi-select ────────────────────────────────────────────────── */
@@ -525,7 +504,7 @@
 </head>
 <body>
 
-{% include "_top_nav.html" with active_section="images" %}
+{% include "_top_nav.html" with active_section="images" nav_actions_template="images/includes/gallery_actions.html" %}
 
 <div class="content-area">
 
@@ -549,23 +528,6 @@
 </aside>
 
 <main class="main">
-  <div class="gallery-header">
-    <div class="ms-toolbar" id="ms-toolbar" hidden>
-      <span class="ms-count">0 selected</span>
-      <button class="ms-cancel-btn" type="button">Cancel</button>
-      <div class="ms-actions-wrap">
-        <button class="ms-actions-btn" id="ms-actions-btn" type="button">
-          Actions
-          <svg width="10" height="6" viewBox="0 0 10 6" fill="none" aria-hidden="true">
-            <path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-        </button>
-        <div class="ms-actions-dropdown" id="ms-actions-dropdown" hidden>
-          <button class="ms-actions-option" id="ms-set-rating-btn" type="button">Set rating</button>
-        </div>
-      </div>
-    </div>
-  </div>
   <div class="gallery-scroll">
     <div id="gallery-results">
       {% include "images/_gallery_results.html" %}

--- a/src/interfaces/templates/images/includes/gallery_actions.html
+++ b/src/interfaces/templates/images/includes/gallery_actions.html
@@ -1,0 +1,19 @@
+{% comment %}
+Image-gallery action toolbar rendered into the top-nav's right-hand slot
+(see _top_nav.html). Owned by the gallery page, not the header.
+{% endcomment %}
+<div class="ms-toolbar" id="ms-toolbar" hidden>
+  <span class="ms-count">0 selected</span>
+  <button class="ms-cancel-btn" type="button">Cancel</button>
+  <div class="ms-actions-wrap">
+    <button class="ms-actions-btn" id="ms-actions-btn" type="button">
+      Actions
+      <svg width="10" height="6" viewBox="0 0 10 6" fill="none" aria-hidden="true">
+        <path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
+    <div class="ms-actions-dropdown" id="ms-actions-dropdown" hidden>
+      <button class="ms-actions-option" id="ms-set-rating-btn" type="button">Set rating</button>
+    </div>
+  </div>
+</div>

--- a/src/interfaces/templates/images/includes/gallery_actions.html
+++ b/src/interfaces/templates/images/includes/gallery_actions.html
@@ -2,6 +2,30 @@
 Image-gallery action toolbar rendered into the top-nav's right-hand slot
 (see _top_nav.html). Owned by the gallery page, not the header.
 {% endcomment %}
+
+{% comment %} View controls: label-mode (compact-only) + Grid/Compact switcher.
+Driven entirely client-side by compact-gallery.js. {% endcomment %}
+<div class="view-controls" id="view-controls">
+  <div class="label-mode" id="label-mode" hidden>
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20.6 13.4l-7.2 7.2a2 2 0 0 1-2.8 0l-7.2-7.2a2 2 0 0 1-.6-1.4V4a2 2 0 0 1 2-2h8a2 2 0 0 1 1.4.6l6.4 6.4a2 2 0 0 1 0 2.8z"/><circle cx="7.5" cy="7.5" r="1.2" fill="#94a3b8" stroke="none"/></svg>
+    <div class="segmented-toggle segmented-toggle--subtle" role="group" aria-label="Recipe name labels">
+      <button type="button" class="segmented-toggle__option" data-label-mode="hover">On hover</button>
+      <button type="button" class="segmented-toggle__option" data-label-mode="always">Always</button>
+    </div>
+  </div>
+
+  <div class="segmented-toggle view-switcher" id="view-switcher" role="group" aria-label="Gallery layout">
+    <button type="button" class="segmented-toggle__option" data-view-mode="grid">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Grid
+    </button>
+    <button type="button" class="segmented-toggle__option" data-view-mode="compact">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="3" width="8" height="5" rx="1"/><rect x="13" y="3" width="8" height="5" rx="1"/><rect x="3" y="10" width="5" height="5" rx="1"/><rect x="10" y="10" width="11" height="5" rx="1"/><rect x="3" y="17" width="11" height="4" rx="1"/><rect x="16" y="17" width="5" height="4" rx="1"/></svg>
+      Compact
+    </button>
+  </div>
+</div>
+
 <div class="ms-toolbar" id="ms-toolbar" hidden>
   <span class="ms-count">0 selected</span>
   <button class="ms-cancel-btn" type="button">Cancel</button>

--- a/src/interfaces/templates/images/includes/gallery_actions.html
+++ b/src/interfaces/templates/images/includes/gallery_actions.html
@@ -6,6 +6,12 @@ Image-gallery action toolbar rendered into the top-nav's right-hand slot
 {% comment %} View controls: label-mode (compact-only) + Grid/Compact switcher.
 Driven entirely client-side by compact-gallery.js. {% endcomment %}
 <div class="view-controls" id="view-controls">
+  <div class="size-control" id="size-control" hidden>
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+    {# min/max/step are kept in sync with MIN/MAX_ROW_HEIGHT in compact-gallery.js #}
+    <input type="range" id="size-slider" class="size-slider" min="120" max="500" step="20" aria-label="Thumbnail size">
+  </div>
+
   <div class="label-mode" id="label-mode" hidden>
     <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20.6 13.4l-7.2 7.2a2 2 0 0 1-2.8 0l-7.2-7.2a2 2 0 0 1-.6-1.4V4a2 2 0 0 1 2-2h8a2 2 0 0 1 1.4.6l6.4 6.4a2 2 0 0 1 0 2.8z"/><circle cx="7.5" cy="7.5" r="1.2" fill="#94a3b8" stroke="none"/></svg>
     <div class="segmented-toggle segmented-toggle--subtle" role="group" aria-label="Recipe name labels">

--- a/src/interfaces/templates/recipes/includes/explorer_actions.html
+++ b/src/interfaces/templates/recipes/includes/explorer_actions.html
@@ -1,0 +1,54 @@
+{% comment %}
+Recipes-explorer action buttons rendered into the top-nav's right-hand slot
+(see _top_nav.html). Owned by the recipes explorer page, not the header.
+{% endcomment %}
+<div class="ms-toolbar" id="ms-toolbar" hidden>
+  <span class="ms-count">0 selected</span>
+  <button class="ms-cancel-btn" type="button">Cancel</button>
+  <div class="ms-actions-wrap">
+    <button class="ms-actions-btn" id="ms-actions-btn" type="button">
+      Actions
+      <svg width="10" height="6" viewBox="0 0 10 6" fill="none" aria-hidden="true">
+        <path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
+    <div class="ms-actions-dropdown" id="ms-actions-dropdown" hidden>
+      <button class="ms-actions-option" id="ms-delete-recipes-btn" type="button">
+        Delete recipes
+      </button>
+      <button class="ms-actions-option" id="ms-create-cards-btn" type="button">
+        Create recipe cards
+      </button>
+    </div>
+  </div>
+</div>
+<div class="header-actions">
+  <a href="{% url 'create-recipe' %}" class="create-recipe-link-btn">
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+    </svg>
+    Create Recipe
+  </a>
+  <div class="create-recipes-wrap">
+    <button class="create-recipes-btn" id="create-recipes-btn">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
+      </svg>
+      Import Recipes
+    </button>
+    <div class="create-recipes-dropdown" id="create-recipes-dropdown" hidden>
+      <button class="create-recipes-option open-import-modal-btn"
+              data-import-url="{% url 'recipes-import' %}"
+              data-import-title="Import Recipes from Images"
+              data-import-desc="Select one or more Fujifilm JPEG files. The recipe settings encoded in their EXIF data will be extracted and saved — the image files themselves are not stored.">
+        Import recipes from images
+      </button>
+      <button class="create-recipes-option open-import-modal-btn"
+              data-import-url="{% url 'recipes-import-qr-cards' %}"
+              data-import-title="Import Recipes from Cards"
+              data-import-desc="Select one or more recipe-card JPEGs. The recipe encoded in each card's QR code will be extracted and saved — the card images themselves are not stored.">
+        Import recipes from recipe cards
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/interfaces/templates/recipes/recipes_explorer.html
+++ b/src/interfaces/templates/recipes/recipes_explorer.html
@@ -148,18 +148,10 @@
       overflow: hidden;
     }
 
-    .gallery-header {
-      display: flex;
-      align-items: center;
-      padding: 1rem 2rem;
-      flex-shrink: 0;
-      min-height: 4rem;
-    }
-
     .recipe-gallery-scroll {
       flex: 1;
       overflow-y: auto;
-      padding: 0 2rem 2rem;
+      padding: 1.5rem 2rem 2rem;
     }
 
     #recipe-gallery-results {
@@ -588,7 +580,7 @@
 </head>
 <body>
 
-{% include "_top_nav.html" with active_section="recipes" %}
+{% include "_top_nav.html" with active_section="recipes" nav_actions_template="recipes/includes/explorer_actions.html" %}
 
 <div class="content-area">
 
@@ -611,58 +603,6 @@
   </aside>
 
   <main class="main">
-    <div class="gallery-header">
-      <div class="ms-toolbar" id="ms-toolbar" hidden>
-        <span class="ms-count">0 selected</span>
-        <button class="ms-cancel-btn" type="button">Cancel</button>
-        <div class="ms-actions-wrap">
-          <button class="ms-actions-btn" id="ms-actions-btn" type="button">
-            Actions
-            <svg width="10" height="6" viewBox="0 0 10 6" fill="none" aria-hidden="true">
-              <path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </button>
-          <div class="ms-actions-dropdown" id="ms-actions-dropdown" hidden>
-            <button class="ms-actions-option" id="ms-delete-recipes-btn" type="button">
-              Delete recipes
-            </button>
-            <button class="ms-actions-option" id="ms-create-cards-btn" type="button">
-              Create recipe cards
-            </button>
-          </div>
-        </div>
-      </div>
-      <div class="header-actions">
-        <a href="{% url 'create-recipe' %}" class="create-recipe-link-btn">
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
-          </svg>
-          Create Recipe
-        </a>
-        <div class="create-recipes-wrap">
-          <button class="create-recipes-btn" id="create-recipes-btn">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
-            </svg>
-            Import Recipes
-          </button>
-          <div class="create-recipes-dropdown" id="create-recipes-dropdown" hidden>
-            <button class="create-recipes-option open-import-modal-btn"
-                    data-import-url="{% url 'recipes-import' %}"
-                    data-import-title="Import Recipes from Images"
-                    data-import-desc="Select one or more Fujifilm JPEG files. The recipe settings encoded in their EXIF data will be extracted and saved — the image files themselves are not stored.">
-              Import recipes from images
-            </button>
-            <button class="create-recipes-option open-import-modal-btn"
-                    data-import-url="{% url 'recipes-import-qr-cards' %}"
-                    data-import-title="Import Recipes from Cards"
-                    data-import-desc="Select one or more recipe-card JPEGs. The recipe encoded in each card's QR code will be extracted and saved — the card images themselves are not stored.">
-              Import recipes from recipe cards
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
 
     <!-- Import modal -->
     <div class="import-overlay" id="import-overlay" hidden>

--- a/tests/functional/test_gallery_view.py
+++ b/tests/functional/test_gallery_view.py
@@ -1,375 +1,77 @@
 import pytest
-from bs4 import BeautifulSoup
-from django.test import override_settings
-from django.utils import timezone
+from django.urls import reverse
 
 from tests.factories import FujifilmRecipeFactory, ImageFactory
 
 
+def _get(client):
+    return client.get(reverse("gallery"))
+
+
 @pytest.mark.django_db
-class TestRecipeMultiSelect:
-    def test_single_recipe_filter_returns_matching_images(self, client):
-        recipe_a = FujifilmRecipeFactory(name="Recipe A")
-        recipe_b = FujifilmRecipeFactory(name="Recipe B")
-        ImageFactory(filename="a.jpg", fujifilm_recipe=recipe_a)
-        ImageFactory(filename="b.jpg", fujifilm_recipe=recipe_b)
-
-        response = client.get("/images/results/", {"recipe_id": recipe_a.id})
+class TestGalleryViewLayoutControls:
+    def test_returns_200(self, client):
+        response = _get(client)
 
         assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        filenames = {c.find(class_="image-filename").text.strip() for c in soup.find_all(class_="image-card")}
-        assert filenames == {"a.jpg"}
 
-    def test_two_recipe_ids_return_images_from_both(self, client):
-        recipe_a = FujifilmRecipeFactory(name="Recipe A")
-        recipe_b = FujifilmRecipeFactory(name="Recipe B")
-        recipe_c = FujifilmRecipeFactory(name="Recipe C")
-        ImageFactory(filename="a.jpg", fujifilm_recipe=recipe_a)
-        ImageFactory(filename="b.jpg", fujifilm_recipe=recipe_b)
-        ImageFactory(filename="c.jpg", fujifilm_recipe=recipe_c)
+    def test_renders_grid_and_compact_view_switcher(self, client):
+        response = _get(client)
 
-        response = client.get(f"/images/results/?recipe_id={recipe_a.id}&recipe_id={recipe_b.id}")
+        content = response.content.decode()
+        assert 'data-view-mode="grid"' in content
+        assert 'data-view-mode="compact"' in content
 
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        filenames = {c.find(class_="image-filename").text.strip() for c in soup.find_all(class_="image-card")}
-        assert filenames == {"a.jpg", "b.jpg"}
-        assert "c.jpg" not in filenames
+    def test_renders_label_mode_control(self, client):
+        response = _get(client)
 
-    def test_full_page_renders_selected_recipe_options_as_selected(self, client):
-        recipe = FujifilmRecipeFactory(name="My Recipe")
-        ImageFactory.create_batch(51, fujifilm_recipe=recipe)
+        content = response.content.decode()
+        assert 'data-label-mode="hover"' in content
+        assert 'data-label-mode="always"' in content
 
-        response = client.get("/images/", {"recipe_id": str(recipe.id)})
+    def test_loads_compact_gallery_script(self, client):
+        response = _get(client)
 
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        option = soup.find("option", {"value": str(recipe.id)})
-        assert option is not None
-        assert option.has_attr("selected")
+        assert "compact-gallery.js" in response.content.decode()
 
-    def test_full_page_renders_recipe_select_as_multiple(self, client):
-        recipe = FujifilmRecipeFactory(name="Named Recipe")
+    def test_gallery_container_defaults_to_grid_layout(self, client):
+        response = _get(client)
+
+        assert 'id="gallery-results" class="layout-grid' in response.content.decode()
+
+
+@pytest.mark.django_db
+class TestGalleryViewCompactOverlay:
+    def test_each_card_renders_a_compact_overlay(self, client):
+        ImageFactory(fujifilm_recipe=FujifilmRecipeFactory())
+
+        response = _get(client)
+
+        assert 'class="image-overlay"' in response.content.decode()
+
+    def test_overlay_shows_the_recipe_name(self, client):
+        recipe = FujifilmRecipeFactory(name="Kodak Portra 400 (v4)")
         ImageFactory(fujifilm_recipe=recipe)
 
-        response = client.get("/images/")
+        response = _get(client)
 
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        recipe_select = soup.find("select", {"name": "recipe_id"})
-        assert recipe_select is not None
-        assert recipe_select.has_attr("multiple")
+        content = response.content.decode()
+        assert "image-overlay-name" in content
+        assert "Kodak Portra 400 (v4)" in content
 
-    def test_recipe_filter_combined_with_field_filter(self, client):
-        recipe_provia = FujifilmRecipeFactory(name="Provia Recipe", film_simulation="Provia")
-        recipe_velvia = FujifilmRecipeFactory(name="Velvia Recipe", film_simulation="Velvia")
-        ImageFactory(filename="provia.jpg", fujifilm_recipe=recipe_provia)
-        ImageFactory(filename="velvia.jpg", fujifilm_recipe=recipe_velvia)
-
-        # Select both recipes but also filter by Provia — only provia.jpg should match
-        response = client.get(
-            f"/images/results/?recipe_id={recipe_provia.id}&recipe_id={recipe_velvia.id}&film_simulation=Provia"
-        )
-
-        soup = BeautifulSoup(response.content, "html.parser")
-        filenames = {c.find(class_="image-filename").text.strip() for c in soup.find_all(class_="image-card")}
-        assert filenames == {"provia.jpg"}
-
-
-@pytest.mark.django_db
-class TestClearFiltersButton:
-    def test_clear_button_is_present_on_gallery_page(self, client):
-        response = client.get("/images/")
-
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        btn = soup.find(class_="clear-filters-btn")
-        assert btn is not None
-
-    def test_clear_button_links_to_gallery_without_filters(self, client):
-        response = client.get("/images/", {"film_simulation": "Provia", "favorites_first": "1"})
-
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        btn = soup.find(class_="clear-filters-btn")
-        href = btn["href"]
-        assert "film_simulation" not in href
-        assert "recipe_id" not in href
-
-    def test_clear_button_preserves_rating_first_preference(self, client):
-        response = client.get("/images/", {"rating_first": "0"})
-
-        soup = BeautifulSoup(response.content, "html.parser")
-        btn = soup.find(class_="clear-filters-btn")
-        assert "rating_first=0" in btn["href"]
-
-    def test_following_clear_button_shows_all_images(self, client):
-        recipe_a = FujifilmRecipeFactory(film_simulation="Provia")
-        recipe_b = FujifilmRecipeFactory(film_simulation="Velvia")
-        ImageFactory(filename="a.jpg", fujifilm_recipe=recipe_a)
-        ImageFactory(filename="b.jpg", fujifilm_recipe=recipe_b)
-
-        # First apply a filter
-        filtered = client.get("/images/results/", {"film_simulation": "Provia"})
-        soup = BeautifulSoup(filtered.content, "html.parser")
-        assert len(soup.find_all(class_="image-card")) == 1
-
-        # Then navigate to the clear URL
-        cleared = client.get("/images/")
-        soup = BeautifulSoup(cleared.content, "html.parser")
-        assert len(soup.find_all(class_="image-card")) == 2
-
-
-@pytest.mark.django_db
-class TestGalleryResultsView:
-    def test_filters_images_by_recipe_name(self, client):
-        # Arrange: 2 recipes, 3 images (2 for recipe_a, 1 for recipe_b)
-        recipe_a = FujifilmRecipeFactory(name="Classic Chrome Recipe", film_simulation="Classic Chrome")
-        recipe_b = FujifilmRecipeFactory(name="Velvia Recipe", film_simulation="Velvia")
-        ImageFactory(filename="fav.jpg",    fujifilm_recipe=recipe_a, is_favorite=True)
-        ImageFactory(filename="normal.jpg", fujifilm_recipe=recipe_a, is_favorite=False)
-        ImageFactory(fujifilm_recipe=recipe_b)
-
-        # Act: filter by recipe_a id
-        response = client.get("/images/results/", {"recipe_id": recipe_a.id})
-
-        assert response.status_code == 200
-
-        soup = BeautifulSoup(response.content, "html.parser")
-        cards = soup.find_all(class_="image-card")
-
-        # Only the 2 images belonging to recipe_a are shown
-        assert len(cards) == 2
-
-        # Favourite image appears first (lower id), then non-favourite
-        filenames = [card.find(class_="image-filename").text.strip() for card in cards]
-        assert filenames == ["fav.jpg", "normal.jpg"]
-
-        # Both cards show the recipe name
-        assert cards[0].find(class_="image-recipe") is not None
-        assert cards[1].find(class_="image-recipe") is not None
-
-
-@pytest.mark.django_db
-class TestGalleryCardRatingLabel:
-    def test_rated_card_shows_rating_label_with_correct_stars(self, client):
-        ImageFactory(filename="rated.jpg", rating=3)
-
-        response = client.get("/images/results/")
-
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        card = soup.find(class_="image-card")
-        label = card.find(class_="image-rating")
-        assert label is not None
-        assert label.text.strip() == "★★★"
-
-    def test_unrated_card_does_not_show_rating_label(self, client):
-        ImageFactory(filename="unrated.jpg", rating=0)
-
-        response = client.get("/images/results/")
-
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        card = soup.find(class_="image-card")
-        assert card.find(class_="image-rating") is None
-
-
-@pytest.mark.django_db
-class TestGalleryInfiniteScroll:
-    @override_settings(GALLERY_PAGE_SIZE=2)
-    def test_first_page_contains_page_size_images(self, client):
-        recipe = FujifilmRecipeFactory(name="Test Recipe")
-        ImageFactory.create_batch(3, fujifilm_recipe=recipe)
-
-        response = client.get("/images/results/", {"page": "1"})
-
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        assert len(soup.find_all(class_="image-card")) == 2
-
-    @override_settings(GALLERY_PAGE_SIZE=2)
-    def test_second_page_contains_remaining_images(self, client):
-        recipe = FujifilmRecipeFactory(name="Test Recipe")
-        ImageFactory.create_batch(3, fujifilm_recipe=recipe)
-
-        response = client.get("/images/results/", {"page": "2"})
-
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        assert len(soup.find_all(class_="image-card")) == 1
-
-    @override_settings(GALLERY_PAGE_SIZE=2)
-    def test_sentinel_present_when_more_pages(self, client):
-        recipe = FujifilmRecipeFactory(name="Test Recipe")
-        ImageFactory.create_batch(3, fujifilm_recipe=recipe)
-
-        response = client.get("/images/results/")
-
-        soup = BeautifulSoup(response.content, "html.parser")
-        sentinel = soup.find(class_="infinite-scroll-sentinel")
-        assert sentinel is not None
-
-    @override_settings(GALLERY_PAGE_SIZE=2)
-    def test_sentinel_absent_on_last_page(self, client):
-        recipe = FujifilmRecipeFactory(name="Test Recipe")
-        ImageFactory.create_batch(3, fujifilm_recipe=recipe)
-
-        response = client.get("/images/results/", {"page": "2"})
-
-        soup = BeautifulSoup(response.content, "html.parser")
-        assert soup.find(class_="infinite-scroll-sentinel") is None
-
-    @override_settings(GALLERY_PAGE_SIZE=2)
-    def test_sentinel_absent_when_single_page(self, client):
-        recipe = FujifilmRecipeFactory(name="Test Recipe")
+    def test_overlay_falls_back_to_film_simulation_without_a_name(self, client):
+        recipe = FujifilmRecipeFactory(name="", film_simulation="Classic Negative")
         ImageFactory(fujifilm_recipe=recipe)
 
-        response = client.get("/images/results/")
+        response = _get(client)
 
-        soup = BeautifulSoup(response.content, "html.parser")
-        assert soup.find(class_="infinite-scroll-sentinel") is None
+        assert "Classic Negative" in response.content.decode()
 
-    @override_settings(GALLERY_PAGE_SIZE=2)
-    def test_sentinel_points_to_next_page(self, client):
-        recipe = FujifilmRecipeFactory(name="Test Recipe")
-        ImageFactory.create_batch(5, fujifilm_recipe=recipe)
+    def test_overlay_shows_rating_stars_when_rated(self, client):
+        ImageFactory(fujifilm_recipe=FujifilmRecipeFactory(), rating=3)
 
-        response = client.get("/images/results/", {"page": "1"})
+        response = _get(client)
 
-        soup = BeautifulSoup(response.content, "html.parser")
-        sentinel = soup.find(class_="infinite-scroll-sentinel")
-        assert sentinel is not None
-        assert sentinel["hx-trigger"] == "intersect root:.gallery-scroll"
-        assert sentinel["hx-swap"] == "outerHTML"
-        assert sentinel["hx-target"] == "#load-more-sentinel"
-        assert '"page": "2"' in sentinel["hx-vals"]
-
-    @override_settings(GALLERY_PAGE_SIZE=2)
-    def test_sentinel_on_middle_page_points_to_next(self, client):
-        recipe = FujifilmRecipeFactory(name="Test Recipe")
-        ImageFactory.create_batch(5, fujifilm_recipe=recipe)
-
-        response = client.get("/images/results/", {"page": "2"})
-
-        soup = BeautifulSoup(response.content, "html.parser")
-        sentinel = soup.find(class_="infinite-scroll-sentinel")
-        assert sentinel is not None
-        assert '"page": "3"' in sentinel["hx-vals"]
-
-    @override_settings(GALLERY_PAGE_SIZE=2)
-    def test_out_of_range_page_returns_last_page(self, client):
-        recipe = FujifilmRecipeFactory(name="Test Recipe")
-        ImageFactory.create_batch(3, fujifilm_recipe=recipe)
-
-        response = client.get("/images/results/", {"page": "999"})
-
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        # Last page has 1 image; django's get_page() clamps to last page
-        assert len(soup.find_all(class_="image-card")) == 1
-
-    @override_settings(GALLERY_PAGE_SIZE=2)
-    def test_page_param_absent_from_filter_change_url(self, client):
-        """Filter changes reset to page 1; the page param should not be in the URL."""
-        recipe = FujifilmRecipeFactory(name="Test Recipe")
-        ImageFactory.create_batch(3, fujifilm_recipe=recipe)
-
-        # Simulate an HTMX filter-change request (no page param)
-        response = client.get("/images/", {"favorites_first": "1"}, HTTP_HX_REQUEST="true")
-
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        # First page worth of images returned
-        assert len(soup.find_all(class_="image-card")) == 2
-        # Sentinel present since there is a second page
-        assert soup.find(class_="infinite-scroll-sentinel") is not None
-
-
-@pytest.mark.django_db
-class TestWBRedBlueFilters:
-    def test_gallery_loads_without_error_when_wb_red_blue_recipes_exist(self, client):
-        recipe = FujifilmRecipeFactory(white_balance_red=3, white_balance_blue=-2)
-        ImageFactory(fujifilm_recipe=recipe)
-
-        response = client.get("/images/")
-
-        assert response.status_code == 200
-
-    def test_filters_images_by_white_balance_red(self, client):
-        recipe_r3 = FujifilmRecipeFactory(white_balance_red=3)
-        recipe_r0 = FujifilmRecipeFactory(white_balance_red=0)
-        ImageFactory(filename="red3.jpg", fujifilm_recipe=recipe_r3)
-        ImageFactory(filename="red0.jpg", fujifilm_recipe=recipe_r0)
-
-        response = client.get("/images/results/", {"white_balance_red": "3"})
-
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        filenames = [c.find(class_="image-filename").text.strip() for c in soup.find_all(class_="image-card")]
-        assert filenames == ["red3.jpg"]
-
-    def test_filters_images_by_white_balance_blue(self, client):
-        recipe_b2 = FujifilmRecipeFactory(white_balance_blue=2)
-        recipe_b0 = FujifilmRecipeFactory(white_balance_blue=0)
-        ImageFactory(filename="blue2.jpg", fujifilm_recipe=recipe_b2)
-        ImageFactory(filename="blue0.jpg", fujifilm_recipe=recipe_b0)
-
-        response = client.get("/images/results/", {"white_balance_blue": "2"})
-
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.content, "html.parser")
-        filenames = [c.find(class_="image-filename").text.strip() for c in soup.find_all(class_="image-card")]
-        assert filenames == ["blue2.jpg"]
-
-
-@pytest.mark.django_db
-class TestRatingFirstToggle:
-    """Three images with ratings 0, 1, 2 where the highest-rated is the oldest.
-    With the toggle enabled the highest-rated image must come first; with it
-    disabled the newest image (rating 0) must come first."""
-
-    def setup_method(self):
-        recipe = FujifilmRecipeFactory(name="Test Recipe")
-        now = timezone.now()
-        ImageFactory(
-            filename="rating2_oldest.jpg",
-            fujifilm_recipe=recipe,
-            rating=2,
-            taken_at=now - timezone.timedelta(days=2),
-        )
-        ImageFactory(
-            filename="rating1_middle.jpg",
-            fujifilm_recipe=recipe,
-            rating=1,
-            taken_at=now - timezone.timedelta(days=1),
-        )
-        ImageFactory(
-            filename="rating0_newest.jpg",
-            fujifilm_recipe=recipe,
-            rating=0,
-            taken_at=now,
-        )
-
-    def _filenames(self, response):
-        soup = BeautifulSoup(response.content, "html.parser")
-        return [card.find(class_="image-filename").text.strip() for card in soup.find_all(class_="image-card")]
-
-    def test_highest_rated_shown_first_when_toggle_enabled(self, client):
-        response = client.get("/images/results/", {"rating_first": "1"})
-
-        assert response.status_code == 200
-        assert self._filenames(response) == ["rating2_oldest.jpg", "rating1_middle.jpg", "rating0_newest.jpg"]
-
-    def test_newest_shown_first_when_toggle_disabled(self, client):
-        response = client.get("/images/results/", {"rating_first": "0"})
-
-        assert response.status_code == 200
-        assert self._filenames(response) == ["rating0_newest.jpg", "rating1_middle.jpg", "rating2_oldest.jpg"]
-
-    def test_highest_rated_shown_first_by_default(self, client):
-        response = client.get("/images/results/")
-
-        assert response.status_code == 200
-        assert self._filenames(response) == ["rating2_oldest.jpg", "rating1_middle.jpg", "rating0_newest.jpg"]
+        content = response.content.decode()
+        assert "image-overlay-rating" in content
+        assert "★★★" in content

--- a/tests/functional/test_gallery_view.py
+++ b/tests/functional/test_gallery_view.py
@@ -29,6 +29,13 @@ class TestGalleryViewLayoutControls:
         assert 'data-label-mode="hover"' in content
         assert 'data-label-mode="always"' in content
 
+    def test_renders_thumbnail_size_slider(self, client):
+        response = _get(client)
+
+        content = response.content.decode()
+        assert 'id="size-slider"' in content
+        assert 'type="range"' in content
+
     def test_loads_compact_gallery_script(self, client):
         response = _get(client)
 


### PR DESCRIPTION
## Summary

Adds an opt-in **Compact** layout to the Images gallery: a Google-Photos-style
justified wall where thumbnails tile edge-to-edge at their true aspect ratio
(no cropping). This fixes the empty gaps the fixed 3-column grid leaves as the
viewport narrows or when images are portrait, and it adapts to any viewport and
mix of aspect ratios.

The existing grid remains the default; Compact is a per-browser choice.



<img width="3706" height="1758" alt="image" src="https://github.com/user-attachments/assets/abcdb7bb-5be7-4b86-a007-d24fa0450d38" />


## What changed

- **Grid / Compact switcher** in the header; switching is instant and fully
  client-side (no reload), remembered in `localStorage`.
- **Justified rows**, each scaled to a single height that fills the content
  width. Aspect ratios are measured from the loaded thumbnails, so nothing new
  is stored server-side.
- **Recipe name + rating overlay**, with an **On hover / Always** label-mode
  control.
- **Thumbnail size slider** (120-500px, default 280, near the grid's 300px) to
  scale the whole wall up or down; re-justifies live.
- The same `.image-card` DOM is reused, so multi-select, rating and the detail
  overlay keep working in both layouts.

