### PR TITLE
Gallery image removal

### DIFF
--- a/docs/web_interface.md
+++ b/docs/web_interface.md
@@ -63,6 +63,10 @@ thousands of "not a Fujifilm photo" entries. You can retry one file, retry every
 retry everything. Retrying a non-Fujifilm file that has not changed does nothing, and the page says
 so on the row.
 
+Images you [remove from the gallery](#212-bulk-actions) that came from inside a folder also appear
+here, under **Removed from the gallery**. Retrying one un-ignores it, so the next sync imports it
+again (its previous rating, favourite and album membership are not restored).
+
 ### 1.3 Automatic sync on startup
 
 Every time you start the app with `make start`, Filmcase runs a sync pass across all
@@ -123,6 +127,11 @@ mode, then open the _Actions_ menu to choose what to do with the selection.
   in the image detail view. Pick a rating (or the ✕ to clear it) and confirm to apply it to
   every selected image at once. The gallery reloads when you close the modal so the updated
   star counts appear on the cards.
+- **Remove**: a modal asks you to confirm removing the selected images from the gallery. No
+  file is ever deleted from disk. An image whose file sits inside a registered library folder
+  is also added to that folder's ignore list, so a later sync does not re-import it; you can
+  undo that from the folder's [ignored files](#12-files-that-could-not-be-imported). An image outside any library
+  folder is simply removed. The gallery reloads when you close the modal.
 
 ---
 

--- a/src/application/usecases/images/remove_images.py
+++ b/src/application/usecases/images/remove_images.py
@@ -1,0 +1,70 @@
+from collections.abc import Sequence
+
+import attrs
+
+from src.data import models
+from src.domain.images import events as image_events
+from src.domain.images import operations as image_operations
+from src.domain.images import queries as image_queries
+from src.domain.library import operations as library_operations
+from src.domain.library import queries as library_queries
+
+
+@attrs.frozen
+class RemoveImagesResult:
+    removed_count: int
+    ignored_count: int
+    requested_count: int
+
+    @property
+    def not_found_count(self) -> int:
+        return self.requested_count - self.removed_count
+
+    @property
+    def all_succeeded(self) -> bool:
+        return self.not_found_count == 0
+
+
+def remove_images_from_gallery(*, image_ids: Sequence[int]) -> RemoveImagesResult:
+    """
+    Remove every image in *image_ids* from the gallery.
+
+    An image whose file sits under a registered library folder is also recorded
+    as ignored for that folder, so the next sync leaves it alone instead of
+    re-importing a file it now has no catalog entry for. An image under no folder
+    is simply removed, since nothing would re-import it. No file is deleted from
+    disk.
+
+    Ids with no matching row are skipped and counted as not found. The ignore is
+    recorded before the removal: a leftover ignore record for an image that
+    failed to remove is harmless, whereas a removed image with no ignore record
+    would be re-imported on the next sync.
+    """
+    images = image_queries.get_images_by_ids(image_ids=image_ids)
+    removed_count = 0
+    ignored_count = 0
+    for image in images:
+        folder = library_queries.get_owning_folder(filepath=image.filepath)
+        if folder is not None:
+            try:
+                library_operations.record_ignored_image(
+                    folder=folder,
+                    filepath=image.filepath,
+                    reason=models.IgnoredImage.REASON_USER_REMOVED,
+                    detail="Removed from the gallery",
+                )
+                ignored_count += 1
+            except OSError:
+                # The file is already gone from disk. A missing file is never
+                # re-imported, so removing it without an ignore record is safe.
+                pass
+        image_operations.remove_image(
+            image=image,
+            reason=image_events.REMOVE_REASON_USER_REMOVED,
+        )
+        removed_count += 1
+    return RemoveImagesResult(
+        removed_count=removed_count,
+        ignored_count=ignored_count,
+        requested_count=len(image_ids),
+    )

--- a/src/data/models/_ignored_image.py
+++ b/src/data/models/_ignored_image.py
@@ -11,6 +11,10 @@ from ._library import LibraryFolder
 _IGNORED_NO_FILM_SIMULATION = "IGNORED_NO_FILM_SIMULATION"
 _IGNORED_INVALID_RECIPE_DATA = "IGNORED_INVALID_RECIPE_DATA"
 _IGNORED_ERROR = "IGNORED_ERROR"
+# Not an import failure: the file was imported and then removed from the gallery
+# by the user, who chose to keep it out. The ignore record is what stops the next
+# sync re-importing it.
+_IGNORED_USER_REMOVED = "IGNORED_USER_REMOVED"
 
 _PATH_MAX_LEN = 1024
 _CODE_MAX_LEN = 32
@@ -20,6 +24,7 @@ class IgnoredImage(models.Model):
     REASON_NO_FILM_SIMULATION = _IGNORED_NO_FILM_SIMULATION
     REASON_INVALID_RECIPE_DATA = _IGNORED_INVALID_RECIPE_DATA
     REASON_ERROR = _IGNORED_ERROR
+    REASON_USER_REMOVED = _IGNORED_USER_REMOVED
 
     folder = models.ForeignKey(
         LibraryFolder,

--- a/src/domain/images/events.py
+++ b/src/domain/images/events.py
@@ -33,11 +33,12 @@ TASK_IMAGE_COMPLETED = "task.image.completed"
 SKIP_REASON_NO_FILM_SIMULATION = "no_film_simulation"
 SKIP_REASON_INVALID_RECIPE_DATA = "invalid_recipe_data"
 
-# Values carried on the `reason` field of IMAGE_REMOVED. Both mean the catalog
-# entry was removed; neither involves deleting the file from disk.
+# Values carried on the `reason` field of IMAGE_REMOVED. All mean the catalog
+# entry was removed; none involves deleting the file from disk.
 REMOVE_REASON_FILE_MISSING = "file_missing"
 REMOVE_REASON_FOLDER_REMOVED = "folder_removed"
 REMOVE_REASON_NO_LONGER_IN_LIBRARY = "no_longer_in_library"
+REMOVE_REASON_USER_REMOVED = "user_removed"
 
 
 def publish_event(*, event_type: str, **kwargs: object) -> None:

--- a/src/domain/images/queries.py
+++ b/src/domain/images/queries.py
@@ -581,6 +581,16 @@ def get_images_for_recipe(*, recipe_id: int) -> list[int]:
     )
 
 
+def get_images_by_ids(*, image_ids: Sequence[int]) -> list[models.Image]:
+    """
+    Return the Image rows for *image_ids* that exist, ordered by id.
+
+    Ids with no matching row are simply absent from the result, so the caller
+    can tell which were found by length or membership.
+    """
+    return list(models.Image.objects.filter(pk__in=image_ids).order_by("id"))
+
+
 class Duration(str, enum.Enum):
     WEEK = "week"
     MONTH = "month"

--- a/src/domain/library/queries.py
+++ b/src/domain/library/queries.py
@@ -243,6 +243,24 @@ def get_image_ids_no_longer_covered(*, folder_path: str) -> list[int]:
     return list(uncovered.order_by("id").values_list("id", flat=True))
 
 
+def get_owning_folder(*, filepath: str) -> models.LibraryFolder | None:
+    """
+    Return the registered library folder that *filepath* sits under, or None if
+    no folder covers it.
+
+    Folders may nest, so a file below ``/photos/2024`` is under both ``/photos``
+    and ``/photos/2024``. The most specific one owns it, so the folder with the
+    longest matching path prefix wins. Membership is purely lexical, the same
+    path-prefix inference the coverage queries above use (ADR 015).
+    """
+    owning: models.LibraryFolder | None = None
+    for folder in models.LibraryFolder.objects.all():
+        if filepath.startswith(_folder_prefix(path=folder.path)):
+            if owning is None or len(folder.path) > len(owning.path):
+                owning = folder
+    return owning
+
+
 def get_active_sync_run(*, folder_id: int) -> models.SyncRun | None:
     """
     Return the in-progress (scanning or processing) sync run for *folder_id*, or

--- a/src/interfaces/images/urls.py
+++ b/src/interfaces/images/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path("images/", views.Gallery.as_view(), name="gallery"),
     path("images/results/", views.GalleryResults.as_view(), name="gallery-results"),
     path("images/set-rating/", views.SetImagesRating.as_view(), name="images-set-rating"),
+    path("images/remove/", views.RemoveImages.as_view(), name="images-remove"),
     path("images/file/<int:image_id>/", views.ImageFile.as_view(), name="image-file"),
     path("images/<int:image_id>/", views.ImageDetail.as_view(), name="image-detail"),
     path("images/<int:image_id>/set-rating/", views.SetImageRating.as_view(), name="image-set-rating"),

--- a/src/interfaces/images/views.py
+++ b/src/interfaces/images/views.py
@@ -7,6 +7,7 @@ from django import http
 from django import shortcuts
 from django.views import generic
 
+from src.application.usecases.images import remove_images as remove_images_uc
 from src.application.usecases.images import set_images_rating as set_images_rating_uc
 from src.data import models
 from src.domain.images import filter_queries
@@ -232,6 +233,43 @@ class SetImagesRating(generic.View):
                 "not_found_count": result.not_found_count,
                 "rating": rating,
                 "all_succeeded": result.not_found_count == 0,
+            },
+        )
+
+
+class RemoveImages(generic.View):
+    """
+    Remove a batch of selected images from the gallery.
+
+    Images under a registered library folder are also added to that folder's
+    ignore list so a later sync does not re-import them; no file is deleted from
+    disk. Returns an HTML result fragment for the multi-select modal.
+    """
+
+    def post(self, request: http.HttpRequest) -> http.HttpResponse:
+        image_ids_raw = request.POST.getlist("image_ids")
+        try:
+            image_ids = [int(pk) for pk in image_ids_raw]
+        except (ValueError, TypeError):
+            return http.HttpResponseBadRequest("image_ids must be integers")
+
+        try:
+            result = remove_images_uc.remove_images_from_gallery(image_ids=image_ids)
+        except Exception:
+            structlog.get_logger().exception("Unexpected error in RemoveImages.post")
+            return shortcuts.render(
+                request,
+                "images/partials/remove_images_result.html",
+                {"error": "An unexpected error occurred. Please try again."},
+            )
+        return shortcuts.render(
+            request,
+            "images/partials/remove_images_result.html",
+            {
+                "removed_count": result.removed_count,
+                "ignored_count": result.ignored_count,
+                "not_found_count": result.not_found_count,
+                "all_succeeded": result.all_succeeded,
             },
         )
 

--- a/src/interfaces/library/views.py
+++ b/src/interfaces/library/views.py
@@ -219,10 +219,15 @@ _IGNORED_REASON_LABELS = {
     models.IgnoredImage.REASON_NO_FILM_SIMULATION: "Not a Fujifilm photo",
     models.IgnoredImage.REASON_INVALID_RECIPE_DATA: "Recipe could not be read",
     models.IgnoredImage.REASON_ERROR: "Failed with an error",
+    models.IgnoredImage.REASON_USER_REMOVED: "Removed from the gallery",
 }
-# Only an error is worth retrying by hand. The other two are verdicts on the
-# file's own contents, so an unchanged file gets the same verdict again.
-_RETRY_CHANGES_SOMETHING = {models.IgnoredImage.REASON_ERROR}
+# An error is worth retrying by hand, and a user-removed file is un-ignored to
+# let the next sync import it again. The other two are verdicts on the file's own
+# contents, so an unchanged file gets the same verdict again.
+_RETRY_CHANGES_SOMETHING = {
+    models.IgnoredImage.REASON_ERROR,
+    models.IgnoredImage.REASON_USER_REMOVED,
+}
 
 
 def _ignored_image_data(ignored: models.IgnoredImage) -> library_dataclasses.IgnoredImageData:

--- a/src/interfaces/templates/images/gallery.html
+++ b/src/interfaces/templates/images/gallery.html
@@ -816,6 +816,96 @@
   }());
 </script>
 
+<!-- Remove images modal -->
+<div class="import-overlay" id="remove-images-overlay" hidden>
+  <div class="import-modal" role="dialog" aria-modal="true" aria-labelledby="remove-images-modal-title">
+    <button class="import-modal__close" id="close-remove-images-btn" aria-label="Close">&#x2715;</button>
+    <div id="remove-images-modal-body">
+      <h2 id="remove-images-modal-title">Remove Images</h2>
+      <p class="import-modal__desc">
+        Remove these <strong id="remove-images-count">0</strong> images from the gallery?
+      </p>
+      <p class="import-modal__desc">
+        Images inside a library folder are also added to that folder's ignore list,
+        so a later sync will not bring them back. You can undo that from the
+        folder's ignored files. Images outside any library folder are just removed.
+        No file is deleted from disk.
+      </p>
+      <form id="remove-images-form"
+            hx-post="{% url 'images-remove' %}"
+            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+            hx-target="#remove-images-modal-body"
+            hx-swap="innerHTML">
+        <div id="remove-images-pks-container"></div>
+        <div class="delete-confirm__actions">
+          <button type="button" class="delete-confirm__no-btn" id="remove-images-cancel-btn">Cancel</button>
+          <button type="submit" class="delete-confirm__yes-btn" id="remove-images-confirm-btn">Remove</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var overlay       = document.getElementById('remove-images-overlay');
+    var closeBtn      = document.getElementById('close-remove-images-btn');
+    var _allSucceeded = false;
+
+    // Snapshot the confirm form once so we can restore it after a submission
+    // replaces the modal body with the result partial.
+    var _confirmHTML = document.getElementById('remove-images-modal-body').innerHTML;
+
+    function handleClose() {
+      overlay.hidden = true;
+      if (_allSucceeded) {
+        _allSucceeded = false;
+        location.reload();
+      }
+    }
+
+    function openModal() {
+      _allSucceeded = false;
+
+      // Restore the confirm form (in case a previous submission replaced it).
+      var body = document.getElementById('remove-images-modal-body');
+      body.innerHTML = _confirmHTML;
+      htmx.process(body);
+
+      var pks = imageMultiSelect.getSelectedPks();
+      document.getElementById('remove-images-count').textContent = pks.length;
+      var container = document.getElementById('remove-images-pks-container');
+      pks.forEach(function (pk) {
+        var input = document.createElement('input');
+        input.type  = 'hidden';
+        input.name  = 'image_ids';
+        input.value = pk;
+        container.appendChild(input);
+      });
+
+      overlay.hidden = false;
+      document.getElementById('ms-actions-dropdown').hidden = true;
+    }
+
+    document.getElementById('ms-remove-btn').addEventListener('click', openModal);
+    closeBtn.addEventListener('click', handleClose);
+
+    // Delegate Cancel button and backdrop clicks (Cancel is inside the modal
+    // body and gets replaced by HTMX after a submission).
+    overlay.addEventListener('click', function (e) {
+      if (e.target === overlay || e.target.closest('#remove-images-cancel-btn')) {
+        handleClose();
+      }
+    });
+
+    document.body.addEventListener('htmx:afterSwap', function (e) {
+      if (e.detail.target.id !== 'remove-images-modal-body') return;
+      var resultEl = e.detail.target.querySelector('[data-all-succeeded]');
+      _allSucceeded = !!(resultEl && resultEl.dataset.allSucceeded === 'true');
+    });
+  }());
+</script>
+
 <script>
   // Multi-select recipe dropdown with search and removable tags.
   // Tom Select hides the original <select multiple>, so we relay its onChange

--- a/src/interfaces/templates/images/includes/gallery_actions.html
+++ b/src/interfaces/templates/images/includes/gallery_actions.html
@@ -44,6 +44,7 @@ Driven entirely client-side by compact-gallery.js. {% endcomment %}
     </button>
     <div class="ms-actions-dropdown" id="ms-actions-dropdown" hidden>
       <button class="ms-actions-option" id="ms-set-rating-btn" type="button">Set rating</button>
+      <button class="ms-actions-option" id="ms-remove-btn" type="button">Remove</button>
     </div>
   </div>
 </div>

--- a/src/interfaces/templates/images/partials/remove_images_result.html
+++ b/src/interfaces/templates/images/partials/remove_images_result.html
@@ -1,0 +1,31 @@
+{% if error %}
+<div class="remove-result remove-result--error" data-all-succeeded="false">
+  <p class="remove-result__message">{{ error }}</p>
+</div>
+
+{% else %}
+<div class="remove-result" data-all-succeeded="{{ all_succeeded|yesno:'true,false' }}">
+  {% if removed_count %}
+  <p class="remove-result__message remove-result__message--success">
+    {{ removed_count }} image{{ removed_count|pluralize }} removed.
+  </p>
+  {% endif %}
+
+  {% if ignored_count %}
+  <p class="remove-result__message">
+    {{ ignored_count }} added to the ignore list so a later sync will not bring
+    {% if ignored_count == 1 %}it{% else %}them{% endif %} back.
+  </p>
+  {% endif %}
+
+  {% if not_found_count %}
+  <p class="remove-result__message remove-result__message--warning">
+    {{ not_found_count }} image{{ not_found_count|pluralize }} could not be found.
+  </p>
+  {% endif %}
+
+  {% if not removed_count and not not_found_count %}
+  <p class="remove-result__message">No images were removed.</p>
+  {% endif %}
+</div>
+{% endif %}

--- a/tests/functional/test_remove_images_view.py
+++ b/tests/functional/test_remove_images_view.py
@@ -1,0 +1,134 @@
+from unittest.mock import patch
+
+import pytest
+from bs4 import BeautifulSoup
+
+from src.data import models
+from tests.factories import ImageFactory, LibraryFolderFactory
+
+
+def _photo(*, folder_path, name, content=b"\xff\xd8abc"):
+    path = folder_path / name
+    path.write_bytes(content)
+    return path
+
+
+@pytest.mark.django_db
+class TestRemoveImagesViewMethodGuard:
+    def test_get_returns_405(self, client) -> None:
+        response = client.get("/images/remove/")
+        assert response.status_code == 405
+
+
+@pytest.mark.django_db
+class TestRemoveImagesGalleryPresence:
+    def test_remove_action_button_is_in_actions_dropdown(self, client) -> None:
+        response = client.get("/images/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find("button", id="ms-remove-btn") is not None
+
+    def test_remove_modal_is_in_page(self, client) -> None:
+        response = client.get("/images/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(id="remove-images-overlay") is not None
+
+    def test_form_posts_to_correct_url(self, client) -> None:
+        response = client.get("/images/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        form = soup.find("form", id="remove-images-form")
+        assert form is not None
+        assert form.get("hx-post") == "/images/remove/"
+
+    def test_modal_warns_about_the_ignore_list(self, client) -> None:
+        response = client.get("/images/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        modal_text = soup.find(id="remove-images-modal-body").get_text().lower()
+        assert "ignore list" in modal_text
+
+
+@pytest.mark.django_db
+class TestRemoveImagesViewSuccess:
+    def test_returns_200(self, client, tmp_path) -> None:
+        image = ImageFactory(filepath=str(_photo(folder_path=tmp_path, name="a.jpg")))
+        response = client.post("/images/remove/", {"image_ids": [image.pk]})
+        assert response.status_code == 200
+
+    def test_removes_every_selected_image(self, client, tmp_path) -> None:
+        images = [
+            ImageFactory(filepath=str(_photo(folder_path=tmp_path, name=f"{n}.jpg")))
+            for n in range(3)
+        ]
+        client.post("/images/remove/", {"image_ids": [image.pk for image in images]})
+        assert not models.Image.objects.filter(pk__in=[image.pk for image in images]).exists()
+
+    def test_image_under_a_folder_is_added_to_the_ignore_list(self, client, tmp_path) -> None:
+        folder = LibraryFolderFactory(path=str(tmp_path))
+        photo = _photo(folder_path=tmp_path, name="a.jpg")
+        image = ImageFactory(filepath=str(photo))
+
+        client.post("/images/remove/", {"image_ids": [image.pk]})
+
+        ignored = models.IgnoredImage.objects.get(filepath=str(photo))
+        assert ignored.reason == models.IgnoredImage.REASON_USER_REMOVED
+        assert ignored.folder_id == folder.pk
+
+    def test_image_under_no_folder_is_not_ignored(self, client, tmp_path) -> None:
+        photo = _photo(folder_path=tmp_path, name="a.jpg")
+        image = ImageFactory(filepath=str(photo))
+
+        client.post("/images/remove/", {"image_ids": [image.pk]})
+
+        assert not models.IgnoredImage.objects.filter(filepath=str(photo)).exists()
+
+    def test_keeps_the_file_on_disk(self, client, tmp_path) -> None:
+        photo = _photo(folder_path=tmp_path, name="a.jpg")
+        image = ImageFactory(filepath=str(photo))
+
+        client.post("/images/remove/", {"image_ids": [image.pk]})
+
+        assert photo.exists()
+
+    def test_marks_all_succeeded_when_all_removed(self, client, tmp_path) -> None:
+        image = ImageFactory(filepath=str(_photo(folder_path=tmp_path, name="a.jpg")))
+        response = client.post("/images/remove/", {"image_ids": [image.pk]})
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(attrs={"data-all-succeeded": "true"}) is not None
+
+
+@pytest.mark.django_db
+class TestRemoveImagesViewPartialFailure:
+    def test_missing_id_marks_not_all_succeeded(self, client, tmp_path) -> None:
+        image = ImageFactory(filepath=str(_photo(folder_path=tmp_path, name="a.jpg")))
+        response = client.post(
+            "/images/remove/",
+            {"image_ids": [image.pk, image.pk + 1000]},
+        )
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(attrs={"data-all-succeeded": "false"}) is not None
+
+    def test_missing_id_shows_not_found_message(self, client, tmp_path) -> None:
+        image = ImageFactory(filepath=str(_photo(folder_path=tmp_path, name="a.jpg")))
+        response = client.post(
+            "/images/remove/",
+            {"image_ids": [image.pk, image.pk + 1000]},
+        )
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert "could not be found" in soup.get_text().lower()
+
+
+@pytest.mark.django_db
+class TestRemoveImagesViewBadRequest:
+    def test_non_integer_image_ids_returns_400(self, client) -> None:
+        response = client.post("/images/remove/", {"image_ids": ["abc"]})
+        assert response.status_code == 400
+
+    def test_unexpected_exception_shows_error_message(self, client, tmp_path) -> None:
+        image = ImageFactory(filepath=str(_photo(folder_path=tmp_path, name="a.jpg")))
+        with patch(
+            "src.interfaces.images.views.remove_images_uc.remove_images_from_gallery",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = client.post("/images/remove/", {"image_ids": [image.pk]})
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert "unexpected" in soup.get_text().lower()

--- a/tests/integration/application/images/test_remove_images.py
+++ b/tests/integration/application/images/test_remove_images.py
@@ -1,0 +1,86 @@
+import pytest
+
+from src.application.usecases.images.remove_images import remove_images_from_gallery
+from src.data import models
+from tests.factories import ImageFactory, LibraryFolderFactory
+
+
+def _photo(*, folder_path, name, content=b"\xff\xd8abc"):
+    path = folder_path / name
+    path.write_bytes(content)
+    return path
+
+
+@pytest.mark.django_db
+class TestRemoveImagesFromGallery:
+    def test_removes_and_ignores_an_image_under_a_folder(self, tmp_path):
+        folder = LibraryFolderFactory(path=str(tmp_path))
+        photo = _photo(folder_path=tmp_path, name="a.jpg")
+        image = ImageFactory(filepath=str(photo))
+
+        result = remove_images_from_gallery(image_ids=[image.pk])
+
+        assert result.removed_count == 1
+        assert result.ignored_count == 1
+        assert result.not_found_count == 0
+        assert result.all_succeeded is True
+        assert not models.Image.objects.filter(pk=image.pk).exists()
+        ignored = models.IgnoredImage.objects.get(filepath=str(photo))
+        assert ignored.reason == models.IgnoredImage.REASON_USER_REMOVED
+        assert ignored.folder_id == folder.pk
+
+    def test_keeps_the_file_on_disk(self, tmp_path):
+        LibraryFolderFactory(path=str(tmp_path))
+        photo = _photo(folder_path=tmp_path, name="a.jpg")
+        image = ImageFactory(filepath=str(photo))
+
+        remove_images_from_gallery(image_ids=[image.pk])
+
+        assert photo.exists()
+
+    def test_removes_without_ignoring_an_image_under_no_folder(self, tmp_path):
+        photo = _photo(folder_path=tmp_path, name="a.jpg")
+        image = ImageFactory(filepath=str(photo))
+
+        result = remove_images_from_gallery(image_ids=[image.pk])
+
+        assert result.removed_count == 1
+        assert result.ignored_count == 0
+        assert not models.Image.objects.filter(pk=image.pk).exists()
+        assert not models.IgnoredImage.objects.filter(filepath=str(photo)).exists()
+
+    def test_removes_without_ignoring_when_the_file_is_gone_from_disk(self, tmp_path):
+        LibraryFolderFactory(path=str(tmp_path))
+        image = ImageFactory(filepath=str(tmp_path / "missing.jpg"))
+
+        result = remove_images_from_gallery(image_ids=[image.pk])
+
+        assert result.removed_count == 1
+        assert result.ignored_count == 0
+        assert not models.Image.objects.filter(pk=image.pk).exists()
+        assert not models.IgnoredImage.objects.filter(filepath=image.filepath).exists()
+
+    def test_counts_an_unknown_id_as_not_found(self, tmp_path):
+        folder = LibraryFolderFactory(path=str(tmp_path))
+        photo = _photo(folder_path=tmp_path, name="a.jpg")
+        image = ImageFactory(filepath=str(photo))
+
+        result = remove_images_from_gallery(image_ids=[image.pk, 9999])
+
+        assert result.requested_count == 2
+        assert result.removed_count == 1
+        assert result.not_found_count == 1
+        assert result.all_succeeded is False
+        assert folder  # the surviving folder still exists
+
+    def test_removes_a_mix_of_covered_and_uncovered_images(self, tmp_path):
+        LibraryFolderFactory(path=str(tmp_path))
+        covered = ImageFactory(filepath=str(_photo(folder_path=tmp_path, name="a.jpg")))
+        uncovered_dir = tmp_path.parent / "outside"
+        uncovered_dir.mkdir()
+        uncovered = ImageFactory(filepath=str(_photo(folder_path=uncovered_dir, name="b.jpg")))
+
+        result = remove_images_from_gallery(image_ids=[covered.pk, uncovered.pk])
+
+        assert result.removed_count == 2
+        assert result.ignored_count == 1

--- a/tests/integration/domain/images/test_get_images_by_ids_query.py
+++ b/tests/integration/domain/images/test_get_images_by_ids_query.py
@@ -1,0 +1,25 @@
+import pytest
+
+from src.domain.images.queries import get_images_by_ids
+from tests.factories import ImageFactory
+
+
+@pytest.mark.django_db
+class TestGetImagesByIds:
+    def test_returns_the_matching_images_ordered_by_id(self):
+        first = ImageFactory(filepath="/photos/a.jpg")
+        second = ImageFactory(filepath="/photos/b.jpg")
+
+        result = get_images_by_ids(image_ids=[second.pk, first.pk])
+
+        assert [image.pk for image in result] == [first.pk, second.pk]
+
+    def test_omits_ids_with_no_matching_row(self):
+        image = ImageFactory(filepath="/photos/a.jpg")
+
+        result = get_images_by_ids(image_ids=[image.pk, 9999])
+
+        assert [image.pk for image in result] == [image.pk]
+
+    def test_returns_empty_for_no_ids(self):
+        assert get_images_by_ids(image_ids=[]) == []

--- a/tests/integration/domain/library/test_exclusive_ownership_queries.py
+++ b/tests/integration/domain/library/test_exclusive_ownership_queries.py
@@ -5,6 +5,7 @@ from src.domain.library.queries import (
     count_exclusively_owned_images,
     get_image_ids_no_longer_covered,
     get_exclusively_owned_image_ids,
+    get_owning_folder,
 )
 from tests.factories import ImageFactory, LibraryFolderFactory
 
@@ -145,3 +146,30 @@ class TestOwnershipIncludesAPreviousPath:
         ImageFactory(filepath="/photos/2023/a.jpg")
 
         assert get_exclusively_owned_image_ids(folder_id=folder.pk) == []
+
+
+@pytest.mark.django_db
+class TestGetOwningFolder:
+    def test_returns_the_folder_a_file_sits_under(self):
+        folder = LibraryFolderFactory(path="/photos")
+
+        assert get_owning_folder(filepath="/photos/2024/DSCF0001.JPG") == folder
+
+    def test_returns_none_when_no_folder_covers_the_file(self):
+        LibraryFolderFactory(path="/photos")
+
+        assert get_owning_folder(filepath="/elsewhere/DSCF0001.JPG") is None
+
+    def test_returns_none_when_there_are_no_folders(self):
+        assert get_owning_folder(filepath="/photos/DSCF0001.JPG") is None
+
+    def test_the_most_specific_nested_folder_wins(self):
+        LibraryFolderFactory(path="/photos")
+        inner = LibraryFolderFactory(path="/photos/2024")
+
+        assert get_owning_folder(filepath="/photos/2024/DSCF0001.JPG") == inner
+
+    def test_does_not_claim_a_sibling_sharing_the_name_as_a_prefix(self):
+        LibraryFolderFactory(path="/photos")
+
+        assert get_owning_folder(filepath="/photos-old/DSCF0001.JPG") is None


### PR DESCRIPTION
<img width="3084" height="1566" alt="image" src="https://github.com/user-attachments/assets/95626212-ec61-49cd-abd5-7d3947bebe5f" />

## What

Adds a bulk **Remove** action to the gallery's multi-select Actions menu, next to Set rating, for taking images out of the gallery on demand. Previously removal only happened implicitly during a library sync or prune.

Removing never deletes the file from disk. An image whose file sits under a registered library folder is also added to that folder's ignore list, so the next sync does not re-import a file it no longer has a catalog entry for. An image outside any library folder is simply removed. The confirm dialog spells out both behaviours before you commit.

## How

Built across the four layers, reusing the existing `remove_image` and `record_ignored_image` operations and mirroring the existing bulk Set-rating feature end to end:

- **Data**: new `IgnoredImage.REASON_USER_REMOVED` code (no migration, the field has no choices).
- **Domain**: `get_owning_folder` (most-specific folder by path prefix), `get_images_by_ids`, and a `REMOVE_REASON_USER_REMOVED` event reason.
- **Application**: `remove_images_from_gallery` use case, recording the ignore before removing per image and skipping the ignore when the file is already gone from disk.
- **Interface**: `RemoveImages` view at `images/remove/`, a result partial, the Actions-menu entry and confirm modal, and a "Removed from the gallery" label plus retry (un-ignore) on the ignored-files page, which is the undo.

## Undo

A removed image that was under a folder appears on that folder's ignored-files page under "Removed from the gallery". Retrying un-ignores it, so the next sync imports it again (its previous rating, favourite and album membership are not restored).